### PR TITLE
drop installfolder usage - use lbhomedir if needed

### DIFF
--- a/config/system/general.cfg.default
+++ b/config/system/general.cfg.default
@@ -35,7 +35,6 @@ DOS2UNIX=/usr/bin/dos2unix
 MINISERVERS=1
 CLOUDDNS=dns.loxonecloud.com
 LANG=en
-INSTALLFOLDER=/opt/loxberry
 STARTSETUP=1
 SENDSTATISTIC=1
 VERSION=1.3.0

--- a/sbin/setdatetime.pl
+++ b/sbin/setdatetime.pl
@@ -86,7 +86,7 @@ $timezone            = $cfg->param("TIMESERVER.ZONE");
 $ntpbin              = $cfg->param("BINARIES.NTPDATE");
 $datebin             = $cfg->param("BINARIES.DATE");
 $sudobin             = $cfg->param("BINARIES.SUDO");
-$installdir          = $cfg->param("BASE.INSTALLFOLDER");
+$installdir          = $lbhomedir;
 
 ##########################################################################
 # Main program

--- a/webfrontend/htmlauth/system/admin.cgi
+++ b/webfrontend/htmlauth/system/admin.cgi
@@ -49,7 +49,6 @@ our $help;
 our @help;
 our $helptext;
 our $helplink;
-our $installfolder;
 our $languagefile;
 our $error;
 our $saveformdata;

--- a/webfrontend/htmlauth/system/donate.cgi
+++ b/webfrontend/htmlauth/system/donate.cgi
@@ -44,7 +44,6 @@ our $help;
 our @help;
 our $helptext;
 our $helplink;
-our $installfolder;
 our $languagefile;
 
 ##########################################################################
@@ -55,7 +54,6 @@ our $languagefile;
 my $version = "0.3.2.2";
 
 $cfg                = new Config::Simple("$lbhomedir/config/system/general.cfg");
-$installfolder   = $cfg->param("BASE.INSTALLFOLDER");
 $lang            = $cfg->param("BASE.LANG");
 
 #########################################################################

--- a/webfrontend/htmlauth/system/netshares.cgi
+++ b/webfrontend/htmlauth/system/netshares.cgi
@@ -44,7 +44,6 @@ our $help;
 our @help;
 our $helptext;
 our $helplink;
-our $installfolder;
 our $languagefile;
 
 ##########################################################################

--- a/webfrontend/htmlauth/system/network.cgi
+++ b/webfrontend/htmlauth/system/network.cgi
@@ -47,7 +47,6 @@ our $template_title;
 our $help;
 our @help;
 our $helptext;
-#our $installfolder;
 our $languagefile;
 our $error;
 our $saveformdata;

--- a/webfrontend/htmlauth/system/power.cgi
+++ b/webfrontend/htmlauth/system/power.cgi
@@ -46,7 +46,6 @@ our $help;
 our @help;
 our $helptext;
 our $helplink;
-our $installfolder;
 our $languagefile;
 our $rebootbin;
 our $poweroffbin;
@@ -63,7 +62,6 @@ our $nexturl;
 my $version = "0.3.2.2";
 
 $cfg                = new Config::Simple("$lbsconfigdir/general.cfg");
-#$installfolder   = $cfg->param("BASE.INSTALLFOLDER");
 #$lang            = $cfg->param("BASE.LANG");
 $rebootbin       = $cfg->param("BINARIES.REBOOT");
 $poweroffbin     = $cfg->param("BINARIES.POWEROFF");

--- a/webfrontend/htmlauth/system/timeserver.cgi
+++ b/webfrontend/htmlauth/system/timeserver.cgi
@@ -48,7 +48,6 @@ our $help;
 our @help;
 our $helptext;
 our $helplink;
-# our $installfolder;
 our $languagefile;
 our $error;
 our $saveformdata;
@@ -85,7 +84,6 @@ my $version = "1.2.3.1";
 
 $cfg                = new Config::Simple("$lbsconfigdir/general.cfg");
 
-#$installfolder      = $cfg->param("BASE.INSTALLFOLDER");
 # $lang               = $cfg->param("BASE.LANG");
 $zeitserver         = $cfg->param("TIMESERVER.METHOD");
 $ntpserverurl       = $cfg->param("TIMESERVER.SERVER");

--- a/webfrontend/htmlauth/system/tools/logfile.cgi
+++ b/webfrontend/htmlauth/system/tools/logfile.cgi
@@ -48,11 +48,9 @@ if ($R::lang) {
 }
 my $lang = LoxBerry::System::lblanguage();
 
-# $installfolder   = $cfg->param("BASE.INSTALLFOLDER");
 # $lang            = $cfg->param("BASE.LANG");
 
 # Read translations
-# $languagefile = "$installfolder/templates/system/$lang/language.dat";
 # $phrase = new Config::Simple($languagefile);
 
 #########################################################################

--- a/webfrontend/htmlauth/system/usbstorage.cgi
+++ b/webfrontend/htmlauth/system/usbstorage.cgi
@@ -44,7 +44,6 @@ our $help;
 our @help;
 our $helptext;
 our $helplink;
-our $installfolder;
 our $languagefile;
 
 ##########################################################################


### PR DESCRIPTION
installfolder wird nirgends gebraucht, bzw. wenn, dann sollte an der Stelle lbhomedir zwecks Konsistenz verwendet werden.