### PR TITLE
Revert "drop ancient apache httpd access directives - no need for compat mode"

### DIFF
--- a/webfrontend/htmlauth/.htaccess
+++ b/webfrontend/htmlauth/.htaccess
@@ -1,8 +1,8 @@
 AuthType Basic
 AuthName "Loxberry Administration"
-AuthUserFile ${LB_BASEDIR}/config/system/htusers.dat
-<RequireAny>
-	Require valid-user
-	Require ip 127.0.0.1
-	#Require ip 10.0.0.0/27
-</RequireAny>
+AuthUserFile /opt/loxberry/config/system/htusers.dat
+Require valid-user
+Order allow,deny
+Allow from localhost
+Allow from 127.0.0.1
+Satisfy Any

--- a/webfrontend/htmlauth/system/tools/linfo/cache/.htaccess
+++ b/webfrontend/htmlauth/system/tools/linfo/cache/.htaccess
@@ -1,1 +1,1 @@
-Require all denied
+Deny from all

--- a/webfrontend/htmlauth/system/tools/linfo/tests/.htaccess
+++ b/webfrontend/htmlauth/system/tools/linfo/tests/.htaccess
@@ -1,1 +1,1 @@
-Require all denied
+Deny from all


### PR DESCRIPTION
Reverts mschlenstedt/Loxberry#813

${LB_BASEDIR} existiert nicht - nach Update funktioniert Apache nicht mehr.
