### PR TITLE
added packages list for amd64 architecture

### DIFF
--- a/packages_amd64.txt
+++ b/packages_amd64.txt
@@ -1,0 +1,578 @@
+Desired=Unknown/Install/Remove/Purge/Hold
+| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
+|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
+||/ Name                              Version                           Architecture Description
++++-=================================-=================================-============-===============================================================================
+ii  acl                               2.2.52-3                          armhf        Access control list utilities
+ii  adduser                           3.115                             all          add and remove users and groups
+ii  alsa-utils                        1.1.3-1                           armhf        Utilities for configuring and using ALSA
+ii  alsaplayer-alsa                   0.99.81-2                         armhf        alsaplayer output module for ALSA
+ii  alsaplayer-common                 0.99.81-2                         armhf        audio player (common files)
+ii  alsaplayer-daemon                 0.99.81-2                         armhf        alsaplayer daemon
+ii  alsaplayer-gtk                    0.99.81-2                         armhf        alsaplayer gtk interface
+ii  alsaplayer-jack                   0.99.81-2                         armhf        alsaplayer output module for JACK
+ii  alsaplayer-nas                    0.99.81-2                         armhf        alsaplayer output module for NAS
+ii  alsaplayer-oss                    0.99.81-2                         armhf        alsaplayer output module for OSS
+ii  alsaplayer-text                   0.99.81-2                         armhf        alsaplayer text interface
+ii  alsaplayer-xosd                   0.99.81-2                         armhf        alsaplayer XOSD display module
+ii  apache2                           2.4.25-3+deb9u3                   armhf        Apache HTTP Server
+ii  apache2-bin                       2.4.25-3+deb9u3                   armhf        Apache HTTP Server (modules and other binary files)
+ii  apache2-data                      2.4.25-3+deb9u3                   all          Apache HTTP Server (common files)
+ii  apache2-utils                     2.4.25-3+deb9u3                   armhf        Apache HTTP Server (utility programs for web servers)
+ii  apt                               1.4.8                             armhf        commandline package manager
+ii  apt-listchanges                   3.10                              all          package change history notification tool
+ii  apt-transport-https               1.4.8                             armhf        https download transport for APT
+ii  apt-utils                         1.4.8                             armhf        package management related utility programs
+ii  aptitude                          0.8.7-1                           armhf        terminal-based package manager
+ii  aptitude-common                   0.8.7-1                           all          architecture independent files for the aptitude package manager
+ii  attr                              1:2.4.47-2                        armhf        Utilities for manipulating filesystem extended attributes
+ii  autoconf                          2.69-10                           all          automatic configure script builder
+ii  automake                          1:1.15-6                          all          Tool for generating GNU Standards-compliant Makefiles
+ii  autopoint                         0.19.8.1-2                        all          The autopoint program from GNU gettext
+ii  autotools-dev                     20161112.1                        all          Update infrastructure for config.{guess,sub} files
+ii  avahi-daemon                      0.6.32-2                          armhf        Avahi mDNS/DNS-SD daemon
+ii  base-files                        9.9+rpi1+deb9u3                   armhf        Debian base system miscellaneous files
+ii  base-passwd                       3.5.43                            armhf        Debian base system master password and group files
+ii  bash                              4.4-5                             armhf        GNU Bourne Again SHell
+ii  bash-completion                   1:2.1-4.3                         all          programmable completion for the bash shell
+ii  bind9-host                        1:9.10.3.dfsg.P4-12.3+deb9u4      armhf        Version of 'host' bundled with BIND 9.X
+ii  binutils                          2.28-5                            armhf        GNU assembler, linker and binary utilities
+ii  blends-tasks                      0.6.96                            all          Debian Pure Blends tasks for new installations
+ii  bluez                             5.43-2+rpt2+deb9u2                armhf        Bluetooth tools and daemons
+ii  bsd-mailx                         8.1.2-0.20160123cvs-4             armhf        simple mail user agent
+ii  bsdmainutils                      9.0.12+nmu1                       armhf        collection of more utilities from FreeBSD
+ii  bsdutils                          1:2.29.2-1                        armhf        basic utilities from 4.4BSD-Lite
+ii  build-essential                   12.3                              armhf        Informational list of build-essential packages
+ii  bzip2                             1.0.6-8.1                         armhf        high-quality block-sorting file compressor - utilities
+ii  ca-certificates                   20161130+nmu1                     all          Common CA certificates
+ii  cifs-utils                        2:6.7-1                           armhf        Common Internet File System utilities
+ii  console-setup                     1.164                             all          console font and keymap setup program
+ii  console-setup-linux               1.164                             all          Linux specific part of console-setup
+ii  coreutils                         8.26-3                            armhf        GNU core utilities
+ii  cpanminus                         1.7042-2                          all          script to get, unpack, build and install modules from CPAN
+ii  cpio                              2.11+dfsg-6                       armhf        GNU cpio -- a program to manage archives of files
+ii  cpp                               4:6.3.0-4                         armhf        GNU C preprocessor (cpp)
+ii  cpp-6                             6.3.0-18+rpi1                     armhf        GNU C preprocessor
+ii  crda                              3.18-1                            armhf        wireless Central Regulatory Domain Agent
+ii  cron                              3.0pl1-128                        armhf        process scheduling daemon
+ii  curl                              7.52.1-5+deb9u4                   armhf        command line tool for transferring data with URL syntax
+ii  dash                              0.5.8-2.4                         armhf        POSIX-compliant shell
+ii  dbus                              1.10.24-0+deb9u1                  armhf        simple interprocess messaging system (daemon and utilities)
+ii  dc                                1.06.95-9                         armhf        GNU dc arbitrary precision reverse-polish calculator
+ii  debconf                           1.5.61                            all          Debian configuration management system
+ii  debconf-i18n                      1.5.61                            all          full internationalization support for debconf
+ii  debconf-utils                     1.5.61                            all          debconf utilities
+ii  debianutils                       4.8.1.1                           armhf        Miscellaneous utilities specific to Debian
+ii  default-mysql-client              1.0.2                             all          MySQL database client binaries (metapackage)
+ii  device-tree-compiler              1.4.4-1                           armhf        Device Tree Compiler for Flat Device Trees
+ii  dh-python                         2.20170125                        all          Debian helper tools for packaging Python libraries and applications
+ii  dhcpcd5                           1:6.11.5-1+rpt4                   armhf        DHCPv4, IPv6RA and DHCPv6 client with IPv4LL support
+ii  dialog                            1.3-20160828-2                    armhf        Displays user-friendly dialog boxes from shell scripts
+ii  diffutils                         1:3.5-3                           armhf        File comparison utilities
+ii  distro-info-data                  0.36                              all          information about the distributions' releases (data files)
+ii  dmidecode                         3.0-4                             armhf        SMBIOS/DMI table decoder
+ii  dmsetup                           2:1.02.137-2                      armhf        Linux Kernel Device Mapper userspace library
+ii  dos2unix                          7.3.4-3                           armhf        convert text file line endings between CRLF and LF
+ii  dosfstools                        4.1-1                             armhf        utilities for making and checking MS-DOS FAT filesystems
+ii  dphys-swapfile                    20100506-3                        all          Autogenerate and use a swap file
+ii  dpkg                              1.18.24                           armhf        Debian package management system
+ii  dpkg-dev                          1.18.24                           all          Debian package development tools
+ii  e2fsprogs                         1.43.4-2                          armhf        ext2/ext3/ext4 file system utilities
+ii  ed                                1.10-2.1                          armhf        classic UNIX line editor
+ii  esound-common                     0.2.41-11                         all          Enlightened Sound Daemon - Common files
+ii  expect                            5.45-7+deb9u1                     armhf        Automates interactive applications
+ii  fake-hwclock                      0.11                              all          Save/restore system clock on machines without working RTC hardware
+ii  fakeroot                          1.21-3.1                          armhf        tool for simulating superuser privileges
+ii  fbset                             2.1-29                            armhf        framebuffer device maintenance program
+ii  ffmpeg                            7:3.2.10-1~deb9u1+rpt1            armhf        Tools for transcoding, streaming and playing of multimedia files
+ii  file                              1:5.30-1+deb9u1                   armhf        Recognize the type of data in a file using "magic" numbers
+ii  findutils                         4.6.0+git+20161106-2              armhf        utilities for finding files--find, xargs
+ii  fontconfig                        2.11.0-6.7                        armhf        generic font configuration library - support binaries
+ii  fontconfig-config                 2.11.0-6.7                        all          generic font configuration library - configuration
+ii  fonts-dejavu-core                 2.37-1                            all          Vera font family derivate with additional characters
+ii  fonts-droid-fallback              1:6.0.1r16-1.1                    all          handheld device font with extensive style and language support (fallback)
+ii  fonts-noto-mono                   20161116-1                        all          "No Tofu" monospaced font family with large Unicode coverage
+ii  g++                               4:6.3.0-4                         armhf        GNU C++ compiler
+ii  g++-6                             6.3.0-18+rpi1                     armhf        GNU C++ compiler
+ii  galera-3                          25.3.19-2+rpi1                    armhf        Replication framework for transactional applications
+ii  gawk                              1:4.1.4+dfsg-1                    armhf        GNU awk, a pattern scanning and processing language
+ii  gcc                               4:6.3.0-4                         armhf        GNU C compiler
+ii  gcc-6                             6.3.0-18+rpi1                     armhf        GNU C compiler
+ii  gdb                               7.12-6                            armhf        GNU Debugger
+ii  gdbserver                         7.12-6                            armhf        GNU Debugger (remote server)
+ii  geoip-database                    20170512-1                        all          IP lookup command line tools that use the GeoIP library (country database)
+ii  gettext                           0.19.8.1-2                        armhf        GNU Internationalization utilities
+ii  gettext-base                      0.19.8.1-2                        armhf        GNU Internationalization utilities for the base system
+ii  ghostscript                       9.20~dfsg-3.2+deb9u1              armhf        interpreter for the PostScript language and for PDF
+ii  git                               1:2.11.0-3+deb9u2                 armhf        fast, scalable, distributed revision control system
+ii  git-man                           1:2.11.0-3+deb9u2                 all          fast, scalable, distributed revision control system (manual pages)
+ii  gnome-icon-theme                  3.12.0-2                          all          GNOME Desktop icon theme
+ii  gnupg                             2.1.18-8~deb9u1                   armhf        GNU privacy guard - a free PGP replacement
+ii  gnupg-agent                       2.1.18-8~deb9u1                   armhf        GNU privacy guard - cryptographic agent
+ii  gpgv                              2.1.18-8~deb9u1                   armhf        GNU privacy guard - signature verification tool
+ii  grep                              2.27-2                            armhf        GNU grep, egrep and fgrep
+ii  groff-base                        1.22.3-9                          armhf        GNU troff text-formatting system (base system components)
+ii  gsfonts                           1:8.11+urwcyr1.0.7~pre44-4.3      all          Fonts for the Ghostscript interpreter(s)
+ii  gtk-update-icon-cache             3.22.11-1+rpi3                    armhf        icon theme caching utility
+ii  gzip                              1.6-5                             armhf        GNU compression utilities
+ii  hardlink                          0.3.0                             armhf        Hardlinks multiple copies of the same file
+ii  hicolor-icon-theme                0.15-1                            all          default fallback theme for FreeDesktop.org icon themes
+ii  hostname                          3.18                              armhf        utility to set/show the host name or domain name
+ii  htop                              2.0.2-1                           armhf        interactive processes viewer
+ii  ifplugd                           0.28-19.2                         armhf        configuration daemon for ethernet devices
+ii  ifupdown                          0.8.19                            armhf        high level tools to configure network interfaces
+ii  imagemagick                       8:6.9.7.4+dfsg-11+deb9u4          armhf        image manipulation programs -- binaries
+ii  imagemagick-6-common              8:6.9.7.4+dfsg-11+deb9u4          all          image manipulation programs -- infrastructure
+ii  imagemagick-6.q16                 8:6.9.7.4+dfsg-11+deb9u4          armhf        image manipulation programs -- quantum depth Q16
+ii  imagemagick-common                8:6.9.7.4+dfsg-11+deb9u4          all          image manipulation programs -- infrastructure dummy package
+ii  info                              6.3.0.dfsg.1-1+b1                 armhf        Standalone GNU Info documentation browser
+ii  init                              1.48                              armhf        metapackage ensuring an init system is installed
+ii  init-system-helpers               1.48                              all          helper tools for all init systems
+ii  initramfs-tools                   0.130                             all          generic modular initramfs generator (automation)
+ii  initramfs-tools-core              0.130                             all          generic modular initramfs generator (core tools)
+ii  initscripts                       2.88dsf-59.9                      armhf        scripts for initializing and shutting down the system
+ii  insserv                           1.14.0-5.4                        armhf        boot sequence organizer using LSB init.d script dependency information
+ii  install-info                      6.3.0.dfsg.1-1+b1                 armhf        Manage installed documentation in info format
+ii  iproute2                          4.9.0-1+deb9u1                    armhf        networking and traffic control tools
+ii  iptables                          1.6.0+snapshot20161117-6          armhf        administration tools for packet filtering and NAT
+ii  iputils-ping                      3:20161105-1                      armhf        Tools to test the reachability of network hosts
+ii  isc-dhcp-client                   4.3.5-3                           armhf        DHCP client for automatically obtaining an IP address
+ii  isc-dhcp-common                   4.3.5-3                           armhf        common manpages relevant to all of the isc-dhcp packages
+ii  iso-codes                         3.75-1                            all          ISO language, territory, currency, script codes and their translations
+ii  iw                                4.9-0.1                           armhf        tool for configuring Linux wireless devices
+ii  javascript-common                 11                                all          Base support for JavaScript library packages
+ii  kbd                               2.0.3-2                           armhf        Linux console font and keytable utilities
+ii  keyboard-configuration            1.164                             all          system-wide keyboard preferences
+ii  keyutils                          1.5.9-9                           armhf        Linux Key Management Utilities
+ii  klibc-utils                       2.0.4-9+rpi1                      armhf        small utilities built with klibc for early boot
+ii  kmod                              23-2                              armhf        tools for managing Linux kernel modules
+ii  krb5-locales                      1.15-1+deb9u1                     all          internationalization support for MIT Kerberos
+ii  less                              481-2.1                           armhf        pager program similar to more
+ii  libalgorithm-c3-perl              0.10-1                            all          Perl module for merging hierarchies using the C3 algorithm
+ii  libalgorithm-diff-perl            1.19.03-1                         all          module to find differences between files
+ii  libalgorithm-diff-xs-perl         0.04-4+b2                         armhf        module to find differences between files (XS accelerated)
+ii  libalgorithm-merge-perl           0.08-3                            all          Perl module for three-way merge of textual data
+ii  libalsaplayer-dev                 0.99.81-2                         armhf        alsaplayer plugin library (development files)
+ii  libapache2-mod-php7.0             7.0.27-0+deb9u1                   armhf        server-side, HTML-embedded scripting language (Apache 2 module)
+ii  libarchive-extract-perl           0.80-1                            all          generic archive extracting module
+ii  libasound2-data                   1.1.3-5+rpi3                      all          Configuration files and profiles for ALSA drivers
+ii  libatk1.0-data                    2.22.0-1                          all          Common files for the ATK accessibility toolkit
+ii  libaudit-common                   1:2.6.7-2                         all          Dynamic library for security auditing - common files
+ii  libauthen-pam-perl                0.16-3+b3                         armhf        Perl interface to PAM library
+ii  libauthen-sasl-perl               2.1600-1                          all          Authen::SASL - SASL Authentication framework
+ii  libb-hooks-endofscope-perl        0.21-1                            all          module for executing code after a scope finished compilation
+ii  libblas-common                    3.7.0-2                           armhf        Dependency package for all BLAS implementations
+ii  libblas3                          3.7.0-2                           armhf        Basic Linear Algebra Reference implementations, shared library
+ii  libc-bin                          2.24-11+deb9u1                    armhf        GNU C Library: Binaries
+ii  libc-dev-bin                      2.24-11+deb9u1                    armhf        GNU C Library: Development binaries
+ii  libc-l10n                         2.24-11+deb9u1                    all          GNU C Library: localization files
+ii  libcap2-bin                       1:2.25-1                          armhf        POSIX 1003.1e capabilities (utilities)
+ii  libcgi-fast-perl                  1:2.12-1                          all          CGI subclass for work with FCGI
+ii  libcgi-pm-perl                    4.35-1                            all          module for Common Gateway Interface applications
+ii  libcgi-session-perl               4.48-3                            all          persistent session data in CGI applications
+ii  libclass-accessor-perl            0.34-1                            all          Perl module that automatically generates accessors
+ii  libclass-c3-perl                  0.32-1                            all          pragma for using the C3 method resolution order
+ii  libclass-c3-xs-perl               0.14-1+b1                         armhf        Perl module to accelerate Class::C3
+ii  libclass-data-inheritable-perl    0.08-2                            all          Perl module to create accessors to class data
+ii  libclass-load-perl                0.23-1                            all          module for loading modules by name
+ii  libclass-method-modifiers-perl    2.12-1                            all          Perl module providing method modifiers
+ii  libclass-singleton-perl           1.5-1                             all          implementation of a "Singleton" class
+ii  libclass-xsaccessor-perl          1.19-2+b13                        armhf        Perl module providing fast XS accessors
+ii  libcommon-sense-perl              3.74-2                            armhf        module that implements some sane defaults for Perl programs
+ii  libconfig-crontab-perl            1.42-1                            all          module to read/write Vixie-compatible crontab(5) files
+ii  libconfig-simple-perl             4.59-6                            all          simple configuration file class
+ii  libcpan-changes-perl              0.400002-1                        all          module for reading and writing CPAN Changes files
+ii  libcpan-distnameinfo-perl         0.12-1                            all          module to extract distribution name and version from a filename
+ii  libcpan-meta-check-perl           0.014-1                           all          verify requirements in a CPAN::Meta object
+ii  libcpan-meta-perl                 2.150010-1                        all          Perl module to access CPAN distributions metadata
+ii  libdata-optlist-perl              0.110-1                           all          module to parse and validate simple name/value option pairs
+ii  libdata-perl-perl                 0.002009-1                        all          classes wrapping fundamental Perl data types
+ii  libdata-section-perl              0.200006-1                        all          module to read chunks of data from a module's DATA section
+ii  libdata-uuid-perl                 1.220-1+b2                        armhf        globally/universally unique identifiers (GUIDs/UUIDs)
+ii  libdatetime-locale-perl           1:1.11-1                          all          Perl extension providing localization support for DateTime
+ii  libdatetime-perl                  2:1.42-1                          armhf        module for manipulating dates, times and timestamps
+ii  libdatetime-timezone-perl         1:2.09-1+2017c                    all          framework exposing the Olson time zone database to Perl
+ii  libdbd-mysql-perl                 4.041-2                           armhf        Perl5 database interface to the MariaDB/MySQL database
+ii  libdbd-pg-perl                    3.5.3-1+b2                        armhf        Perl DBI driver for the PostgreSQL database server
+ii  libdbd-sqlite3-perl               1.54-1                            armhf        Perl DBI driver with a self-contained RDBMS
+ii  libdbi-perl                       1.636-1+b1                        armhf        Perl Database Interface (DBI)
+ii  libdevel-caller-perl              2.06-1+b4                         armhf        module providing enhanced caller() support
+ii  libdevel-globaldestruction-perl   0.14-1                            all          module to expose the flag that marks global destruction
+ii  libdevel-lexalias-perl            0.05-1+b4                         armhf        Perl module that provides alias lexical variables
+ii  libdevel-stacktrace-perl          2.0200-1                          all          Perl module containing stack trace and related objects
+ii  libdevice-serialport-perl         1.04-3+b3                         armhf        emulation of Win32::SerialPort for Linux/POSIX
+ii  libdjvulibre-text                 3.5.27.1-7                        all          Linguistic support files for libdjvulibre
+ii  libdns-export162                  1:9.10.3.dfsg.P4-12.3+deb9u4      armhf        Exported DNS Shared Library
+ii  libdpkg-perl                      1.18.24                           all          Dpkg perl modules
+ii  libencode-locale-perl             1.05-1                            all          utility to determine the locale encoding
+ii  liberror-perl                     0.17024-1                         all          Perl module for error/exception handling in an OO-ish way
+ii  libestr0                          0.1.10-2                          armhf        Helper functions for handling strings (lib)
+ii  libeval-closure-perl              0.14-1                            all          Perl module to safely and cleanly create closures via string eval
+ii  libexception-class-perl           1.42-1                            all          module that allows you to declare real exception classes in Perl
+ii  libexif-dev                       0.6.21-2                          armhf        library to parse EXIF files (development files)
+ii  libexporter-tiny-perl             0.042-1                           all          tiny exporter similar to Sub::Exporter
+ii  libfcgi-perl                      0.78-2                            armhf        helper module for FastCGI
+ii  libfile-basedir-perl              0.07-1                            all          Perl module to use the freedesktop basedir specification
+ii  libfile-copy-recursive-perl       0.38-1                            all          Perl extension for recursively copying files and directories
+ii  libfile-desktopentry-perl         0.22-1                            all          Perl module to handle freedesktop .desktop files
+ii  libfile-fcntllock-perl            0.22-3+b2                         armhf        Perl module for file locking with fcntl(2)
+ii  libfile-homedir-perl              1.00-1                            all          Perl module for finding user directories across platforms
+ii  libfile-listing-perl              6.04-1                            all          module to parse directory listings
+ii  libfile-mimeinfo-perl             0.27-1                            all          Perl module to determine file types
+ii  libfile-pushd-perl                1.014-1                           all          module for changing directory temporarily for a limited scope
+ii  libfile-slurp-perl                9999.19-6                         all          single call read & write file routines
+ii  libfile-slurp-tiny-perl           0.003-1                           all          simple, sane and efficient file slurper
+ii  libfile-which-perl                1.21-1                            all          Perl module for searching paths for executable programs
+ii  libfont-afm-perl                  1.20-2                            all          Font::AFM - Interface to Adobe Font Metrics files
+ii  libfreezethaw-perl                0.5001-1                          all          module to serialize and deserialize Perl data structures
+ii  libgdk-pixbuf2.0-common           2.36.5-2+deb9u2                   all          GDK Pixbuf library - data files
+ii  libgetopt-long-descriptive-perl   0.100-1                           all          module that handles command-line arguments with usage text
+ii  libglib2.0-data                   2.50.3-2                          all          Common files for GLib library
+ii  libgs9-common                     9.20~dfsg-3.2+deb9u1              all          interpreter for the PostScript language and for PDF - common files
+ii  libgtk2.0-bin                     2.24.31-2                         armhf        programs for the GTK+ graphical user interface library
+ii  libgtk2.0-common                  2.24.31-2                         all          common files for the GTK+ graphical user interface library
+ii  libhtml-form-perl                 6.03-1                            all          module that represents an HTML form element
+ii  libhtml-format-perl               2.12-1                            all          module for transforming HTML into various formats
+ii  libhtml-parser-perl               3.72-3                            armhf        collection of modules that parse HTML text documents
+ii  libhtml-tagset-perl               3.20-3                            all          Data tables pertaining to HTML
+ii  libhtml-template-perl             2.95-2                            all          module for using HTML templates with Perl
+ii  libhtml-tree-perl                 5.03-2                            all          Perl module to represent and create HTML syntax trees
+ii  libhttp-cookies-perl              6.01-1                            all          HTTP cookie jars
+ii  libhttp-daemon-perl               6.01-1                            all          simple http server class
+ii  libhttp-date-perl                 6.02-1                            all          module of date conversion routines
+ii  libhttp-message-perl              6.11-1                            all          perl interface to HTTP style messages
+ii  libhttp-negotiate-perl            6.00-2                            all          implementation of content negotiation
+ii  libid3tag0-dev                    0.15.1b-12                        armhf        ID3 tag reading library from the MAD project
+ii  libident                          0.22-3.1                          armhf        simple RFC1413 client library - runtime
+ii  libimport-into-perl               1.002005-1                        all          module for importing packages into other packages
+ii  libio-all-lwp-perl                0.14-1                            all          Perl module to use HTTP and FTP URLs with IO::All
+ii  libio-all-perl                    0.86-2                            all          Perl module for unified IO operations
+ii  libio-html-perl                   1.001-1                           all          open an HTML file with automatic charset detection
+ii  libio-interface-perl              1.09-1+b2                         armhf        socket methods to get/set interface characteristics
+ii  libio-socket-multicast-perl       1.12-2+b3                         armhf        module for sending and receiving multicast messages
+ii  libio-socket-ssl-perl             2.044-1                           all          Perl module implementing object oriented interface to SSL sockets
+ii  libio-socket-timeout-perl         0.32-1                            all          IO::Socket with read/write timeout
+ii  libio-stringy-perl                2.111-2                           all          Perl modules for IO from scalars and arrays
+ii  libipc-system-simple-perl         1.25-3                            all          Perl module to run commands simply, with detailed diagnostics
+ii  libisc-export160                  1:9.10.3.dfsg.P4-12.3+deb9u4      armhf        Exported ISC Shared Library
+ii  libjemalloc1                      3.6.0-9.1                         armhf        general-purpose scalable concurrent malloc(3) implementation
+ii  libjpeg-dev                       1:1.5.1-2                         all          Development files for the JPEG library [dummy package]
+ii  libjs-jquery                      3.1.1-2                           all          JavaScript library for dynamic web applications
+ii  libjson-perl                      2.90-1                            all          module for manipulating JSON-formatted data
+ii  libjson-xs-perl                   3.030-1                           armhf        module for manipulating JSON-formatted data (C/XS-accelerated)
+ii  libjxr-tools                      1.1-6                             armhf        JPEG-XR lib - command line apps
+ii  libklibc                          2.0.4-9+rpi1                      armhf        minimal libc subset for use with initramfs
+ii  libldap-common                    2.4.44+dfsg-5+deb9u1              all          OpenLDAP common files for libraries
+ii  liblircclient0                    0.9.4c-9                          armhf        Transitional placeholder for obsoleted liblircclient0
+ii  liblist-allutils-perl             0.12-1                            all          Perl wrapper for modules List::Util and List::MoreUtils
+ii  liblist-moreutils-perl            0.416-1+b1                        armhf        Perl module with additional list functions not found in List::Util
+ii  liblist-someutils-perl            0.53-1                            all          module that provides the stuff missing in List::Util
+ii  liblist-utilsby-perl              0.10-1                            all          higher-order list utility functions
+ii  liblocal-lib-perl                 2.000019-1                        all          module to use a local path for Perl modules
+ii  liblocale-gettext-perl            1.07-3+b1                         armhf        module using libc functions for internationalization in Perl
+ii  liblockfile-bin                   1.14-1                            armhf        support binaries for and cli utilities based on liblockfile
+ii  liblog-message-perl               0.8-1                             all          powerful and flexible message logging mechanism
+ii  liblog-message-simple-perl        0.10-2                            all          simplified interface to Log::Message
+ii  libluajit-5.1-common              2.0.4+dfsg-1                      all          Just in time compiler for Lua - common files
+ii  liblwp-mediatypes-perl            6.02-1                            all          module to guess media type for a file or a URL
+ii  liblwp-protocol-https-perl        6.06-2                            all          HTTPS driver for LWP::UserAgent
+ii  libmagic-mgc                      1:5.30-1+deb9u1                   armhf        File type determination library using "magic" numbers (compiled magic file)
+ii  libmailtools-perl                 2.18-1                            all          Manipulate email in perl programs
+ii  libmcrypt4                        2.5.8-3.3                         armhf        De-/Encryption Library
+ii  libmnl-dev                        1.0.4-2                           armhf        minimalistic Netlink communication library (devel)
+ii  libmodule-build-perl              0.422000-1                        all          framework for building and installing Perl modules
+ii  libmodule-cpanfile-perl           1.1002-1                          all          format for describing CPAN dependencies of Perl applications
+ii  libmodule-implementation-perl     0.09-1                            all          module for loading one of several alternate implementations of a module
+ii  libmodule-load-conditional-perl   0.68-1                            all          module for looking up information about modules
+ii  libmodule-pluggable-perl          5.2-1                             all          module for giving  modules the ability to have plugins
+ii  libmodule-runtime-perl            0.014-2                           all          Perl module for runtime module handling
+ii  libmodule-signature-perl          0.81-1                            all          module to manipulate CPAN SIGNATURE files
+ii  libmoo-perl                       2.002005-1                        all          Minimalist Object Orientation library (with Moose compatibility)
+ii  libmoox-handlesvia-perl           0.001008-2                        all          Moose Native Traits-like behavior for Moo
+ii  libmro-compat-perl                0.12-1                            all          mro::* interface compatibility for Perls < 5.9.5
+ii  libmtp-common                     1.1.13-1                          all          Media Transfer Protocol (MTP) common files
+ii  libmtp-runtime                    1.1.13-1                          armhf        Media Transfer Protocol (MTP) runtime tools
+ii  libnamespace-autoclean-perl       0.28-1                            all          module to remove imported symbols after compilation
+ii  libnamespace-clean-perl           0.27-1                            all          module for keeping imports and functions out of the current namespace
+ii  libnet-dbus-perl                  1.1.0-4+b1                        armhf        Perl extension for the DBus bindings
+ii  libnet-http-perl                  6.12-1                            all          module providing low-level HTTP connection client
+ii  libnet-libidn-perl                0.12.ds-2+b3                      armhf        Perl bindings for GNU Libidn
+ii  libnet-smtp-ssl-perl              1.04-1                            all          Perl module providing SSL support to Net::SMTP
+ii  libnet-ssleay-perl                1.80-1                            armhf        Perl module for Secure Sockets Layer (SSL)
+ii  libnet-subnet-perl                1.03-1                            all          Fast IP-in-subnet matcher module for IPv4 and IPv6
+ii  libnetpbm10                       2:10.0-15.3                       armhf        Graphics conversion tools shared libraries
+ii  libnih-dbus1                      1.0.3-8                           armhf        NIH D-Bus Bindings Library
+ii  libnih1                           1.0.3-8                           armhf        NIH Utility Library
+ii  libopenal-data                    1:1.17.2-4                        all          Software implementation of the OpenAL audio API (data files)
+ii  libpackage-constants-perl         0.06-1                            all          module to list constants defined in a package
+ii  libpackage-stash-perl             0.37-1                            all          module providing routines for manipulating stashes
+ii  libpackage-stash-xs-perl          0.28-3+b1                         armhf        Perl module providing routines for manipulating stashes (XS version)
+ii  libpadwalker-perl                 2.2-2+b1                          armhf        module to inspect and manipulate lexical variables
+ii  libpam-modules-bin                1.1.8-3.6+rpi1                    armhf        Pluggable Authentication Modules for PAM - helper binaries
+ii  libpam-runtime                    1.1.8-3.6+rpi1                    all          Runtime support for the PAM library
+ii  libpaper-utils                    1.1.24+nmu5                       armhf        library for handling paper characteristics (utilities)
+ii  libparams-classify-perl           0.013-6+b1                        armhf        Perl module for argument type classification
+ii  libparams-util-perl               1.07-3+b1                         armhf        Perl extension for simple stand-alone param checking functions
+ii  libparams-validate-perl           1.26-1                            armhf        Perl module to validate parameters to Perl method/function calls
+ii  libparams-validationcompiler-perl 0.23-1                            all          module to build an optimized subroutine parameter validator
+ii  libparse-pmfile-perl              0.41-1                            all          module to parse .pm file as PAUSE does
+ii  libpath-tiny-perl                 0.100-1                           all          file path utility
+ii  libperl4-corelibs-perl            0.003-2                           all          libraries historically supplied with Perl 4
+ii  libperlio-via-timeout-perl        0.32-1                            all          PerlIO layer that adds read & write timeout to a handle
+ii  libpng-tools                      1.6.28-1                          armhf        PNG library - tools (version 1.6)
+ii  libpod-latex-perl                 0.61-2                            all          module to convert Pod data to formatted LaTeX
+ii  libpod-markdown-perl              3.005000-1                        all          module to convert POD to the Markdown file format
+ii  libpod-readme-perl                1.1.2-1                           all          Perl module to convert POD to README file
+ii  libqdbm14                         1.8.78-6.1                        armhf        QDBM Database Libraries without GDBM wrapper[runtime]
+ii  libregexp-common-perl             2016060801-1                      all          module with common regular expressions
+ii  librole-tiny-perl                 2.000005-1                        all          Perl module for minimalist role composition
+ii  libscalar-list-utils-perl         1:1.47-1                          armhf        modules providing common scalar and list utility subroutines
+ii  libsemanage-common                2.6-2                             all          Common files for SELinux policy management libraries
+ii  libsocket6-perl                   0.27-1+b1                         armhf        Perl extensions for IPv6
+ii  libsoftware-license-perl          0.103012-1                        all          module providing templated software licenses
+ii  libspecio-perl                    0.33-1                            all          Perl module providing type constraints and coercions
+ii  libspiffy-perl                    0.41-1                            all          Spiffy Perl Interface Framework For You
+ii  libsqlite0                        2.8.17-14                         armhf        SQLite 2 shared library
+ii  libstrictures-perl                2.000003-1                        all          Perl module to turn on strict and make all warnings fatal
+ii  libstring-shellquote-perl         1.03-1.2                          all          quote strings for passing through the shell
+ii  libsub-exporter-perl              0.986-1                           all          sophisticated exporter for custom-built routines
+ii  libsub-exporter-progressive-perl  0.001013-1                        all          module for using Sub::Exporter only if needed
+ii  libsub-identify-perl              0.12-2+b1                         armhf        module to retrieve names of code references
+ii  libsub-install-perl               0.928-1                           all          module for installing subroutines into packages easily
+ii  libsub-name-perl                  0.21-1                            armhf        module for assigning a new name to referenced sub
+ii  libterm-readkey-perl              2.37-1                            armhf        perl module for simple terminal control
+ii  libterm-ui-perl                   0.46-1                            all          Term::ReadLine UI made easy
+ii  libtest-fatal-perl                0.014-1                           all          module for testing code with exceptions
+ii  libtext-charwidth-perl            0.04-7+b7                         armhf        get display widths of characters on the terminal
+ii  libtext-iconv-perl                1.7-5+b8                          armhf        converts between character sets in Perl
+ii  libtext-soundex-perl              3.4-1+b4                          armhf        implementation of the soundex algorithm
+ii  libtext-template-perl             1.46-1                            all          perl module to process text templates
+ii  libtext-wrapi18n-perl             0.06-7.1                          all          internationalized substitute of Text::Wrap
+ii  libthai-data                      0.1.26-1                          all          Data files for Thai language support library
+ii  libtie-ixhash-perl                1.23-2                            all          Perl module to order associative arrays
+ii  libtimedate-perl                  2.3000-2                          all          collection of modules to manipulate date/time information
+ii  libtool                           2.4.6-2                           all          Generic library support script
+ii  libtry-tiny-perl                  0.28-1                            all          module providing minimalistic try/catch
+ii  libtype-tiny-perl                 1.000005-1                        all          tiny, yet Moo(se)-compatible type constraint
+ii  libtype-tiny-xs-perl              0.012-1+b2                        armhf        boost for some of Type::Tiny's built-in type constraints
+ii  libtypes-serialiser-perl          1.0-1                             all          module providing simple data types for common serialisation formats
+ii  libunicode-utf8-perl              0.60-1+b3                         armhf        encoding and decoding of UTF-8 encoding form
+ii  liburi-perl                       1.71-1                            all          module to manipulate and access URI strings
+ii  libvariable-magic-perl            0.61-1                            armhf        module to associate user-defined magic to variables from Perl
+ii  libwww-perl                       6.15-1                            all          simple and consistent interface to the world-wide web
+ii  libwww-robotrules-perl            6.01-1                            all          database of robots.txt-derived permissions
+ii  libx11-data                       2:1.6.4-3                         all          X11 client-side library
+ii  libx11-protocol-perl              0.56-7                            all          Perl module for the X Window System Protocol, version 11
+ii  libxml-libxml-perl                2.0128+dfsg-1+deb9u1              armhf        Perl interface to the libxml2 library
+ii  libxml-libxml-simple-perl         0.97-1                            all          Perl module that uses the XML::LibXML parser for XML structures
+ii  libxml-namespacesupport-perl      1.11-1                            all          Perl module for supporting simple generic namespaces
+ii  libxml-opml-simplegen-perl        0.07-1                            all          module for creating OPML using XML::Simple
+ii  libxml-parser-perl                2.44-2+b1                         armhf        Perl module for parsing XML files
+ii  libxml-sax-base-perl              1.07-1                            all          base class for SAX drivers and filters
+ii  libxml-sax-expat-perl             0.40-2                            all          Perl module for a SAX2 driver for Expat (XML::Parser)
+ii  libxml-sax-perl                   0.99+dfsg-2                       all          Perl module for using and building Perl SAX2 XML processors
+ii  libxml-simple-perl                2.22-1                            all          Perl module for reading and writing XML
+ii  libxml-twig-perl                  1:3.50-1                          all          Perl module for processing huge XML documents in tree mode
+ii  libxml-xpathengine-perl           0.13-1                            all          re-usable XPath engine for DOM-like trees
+ii  libxosd2                          2.2.14-2.1                        armhf        X On-Screen Display library - runtime
+ii  libzvbi-common                    0.2.35-13                         all          Vertical Blanking Interval decoder (VBI) - common files
+ii  lighttpd                          1.4.45-1                          armhf        fast webserver with minimal memory footprint
+ii  linux-base                        4.5                               all          Linux image base package
+ii  locales                           2.24-11+deb9u1                    all          GNU C Library: National Language (locale) data [support]
+ii  lockfile-progs                    0.1.17                            armhf        Programs for locking and unlocking files and mailboxes
+ii  login                             1:4.4-4.1                         armhf        system login tools
+ii  logrotate                         3.11.0-0.1                        armhf        Log rotation utility
+ii  lsb-base                          9.20161125+rpi1                   all          Linux Standard Base init script functionality
+ii  lsb-release                       9.20161125+rpi1                   all          Linux Standard Base version reporting utility
+ii  lshw                              02.18-0.1                         armhf        information about hardware configuration
+ii  lsof                              4.89+dfsg-0.1                     armhf        Utility to list open files
+ii  lua5.1                            5.1.5-8.1                         armhf        Simple, extensible, embeddable programming language
+ii  luajit                            2.0.4+dfsg-1                      armhf        Just in time compiler for Lua programming language version 5.1
+ii  m4                                1.4.18-1                          armhf        macro processing language
+ii  make                              4.1-9.1                           armhf        utility for directing compilation
+ii  makedev                           2.3.1-93                          all          creates device files in /dev
+ii  man-db                            2.7.6.1-2                         armhf        on-line manual pager
+ii  manpages                          4.10-2                            all          Manual pages about using a GNU/Linux system
+ii  manpages-dev                      4.10-2                            all          Manual pages about using GNU/Linux for development
+ii  mariadb-client-10.1               10.1.23-9+deb9u1                  armhf        MariaDB database client binaries
+ii  mariadb-client-core-10.1          10.1.23-9+deb9u1                  armhf        MariaDB database core client binaries
+ii  mariadb-common                    10.1.23-9+deb9u1                  all          MariaDB common metapackage
+ii  mawk                              1.3.3-17                          armhf        a pattern scanning and text processing language
+ii  mime-support                      3.60                              all          MIME files 'mime.types' & 'mailcap', and support programs
+ii  mount                             2.29.2-1                          armhf        tools for mounting and manipulating filesystems
+ii  mpg123                            1.23.8-1                          armhf        MPEG layer 1/2/3 audio player
+ii  mplayer2                          3:0.23.0-2                        all          transitional dummy package for mpv
+ii  mpv                               0.23.0-2                          armhf        video player based on MPlayer/mplayer2
+ii  multiarch-support                 2.24-11+deb9u1                    armhf        Transitional package to ensure multiarch compatibility
+ii  mysql-client                      5.5.9999+default                  armhf        MySQL database client binaries [transitional]
+ii  mysql-common                      5.8+1.0.2                         all          MySQL database common files, e.g. /etc/mysql/my.cnf
+ii  mysql-utilities                   1.6.4-1                           all          collection of scripts for managing MySQL servers
+ii  nano                              2.7.4-1                           armhf        small, friendly text editor inspired by Pico
+ii  ncdu                              1.12-1                            armhf        ncurses disk usage viewer
+ii  ncftp                             2:3.2.5-2                         armhf        User-friendly and well-featured FTP client
+ii  ncurses-base                      6.0+20161126-1+deb9u1             all          basic terminal type definitions
+ii  ncurses-bin                       6.0+20161126-1+deb9u1             armhf        terminal-related programs and man pages
+ii  ncurses-term                      6.0+20161126-1+deb9u1             all          additional terminal type definitions
+ii  ndiff                             7.40-1                            all          The Network Mapper - result compare utility
+ii  net-tools                         1.60+git20161116.90da8a0-1        armhf        NET-3 networking toolkit
+ii  netbase                           5.4                               all          Basic TCP/IP networking system
+ii  netcat-openbsd                    1.130-3                           armhf        TCP/IP swiss army knife
+ii  netcat-traditional                1.10-41                           armhf        TCP/IP swiss army knife
+ii  netpbm                            2:10.0-15.3                       armhf        Graphics conversion tools between image formats
+ii  nfs-common                        1:1.3.4-2.1                       armhf        NFS support files common to client and server
+ii  nmap                              7.40-1                            armhf        The Network Mapper
+ii  nodejs                            4.8.2~dfsg-1                      armhf        evented I/O for V8 javascript
+ii  ntfs-3g                           1:2016.2.22AR.1+dfsg-1            armhf        read/write NTFS driver for FUSE
+ii  ntpdate                           1:4.2.8p10+dfsg-3+deb9u1          armhf        client for setting system time from NTP servers
+ii  openresolv                        3.8.0-1                           armhf        management framework for resolv.conf
+ii  openssh-client                    1:7.4p1-10+deb9u2                 armhf        secure shell (SSH) client, for secure access to remote machines
+ii  openssh-server                    1:7.4p1-10+deb9u2                 armhf        secure shell (SSH) server, for secure access from remote machines
+ii  openssh-sftp-server               1:7.4p1-10+deb9u2                 armhf        secure shell (SSH) sftp server module, for SFTP access from remote machines
+ii  openssl                           1.1.0f-3+deb9u1                   armhf        Secure Sockets Layer toolkit - cryptographic utility
+ii  oss-compat                        6                                 armhf        Open Sound System (OSS) compatibility package
+ii  p7zip                             16.02+dfsg-3+deb9u1               armhf        7zr file archiver with high compression ratio
+ii  p7zip-full                        16.02+dfsg-3+deb9u1               armhf        7z and 7za file archivers with high compression ratio
+ii  parted                            3.2-17                            armhf        disk partition manipulator
+ii  passwd                            1:4.4-4.1                         armhf        change and administer password and group data
+ii  patch                             2.7.5-1                           armhf        Apply a diff file to an original
+ii  paxctld                           1.2.1-1                           armhf        Daemon to automatically set appropriate PaX flags
+ii  pciutils                          1:3.5.2-1                         armhf        Linux PCI Utilities
+ii  perl                              5.24.1-3+deb9u2                   armhf        Larry Wall's Practical Extraction and Report Language
+ii  perl-base                         5.24.1-3+deb9u2                   armhf        minimal Perl system
+ii  perl-modules-5.24                 5.24.1-3+deb9u2                   all          Core Perl modules
+ii  php                               1:7.0+49                          all          server-side, HTML-embedded scripting language (default)
+ii  php-common                        1:49                              all          Common files for PHP packages
+ii  php-gettext                       1.0.12-0.1                        all          transitional dummy package for php-php-gettext
+ii  php-mbstring                      1:7.0+49                          all          MBSTRING module for PHP [default]
+ii  php-pear                          1:1.10.1+submodules+notgz-9       all          PEAR Base System
+ii  php-php-gettext                   1.0.12-0.1                        all          read gettext MO files directly, without requiring anything other than PHP
+ii  php-soap                          1:7.0+49                          all          SOAP module for PHP [default]
+ii  php-tcpdf                         6.2.12+dfsg2-1                    all          PHP class for generating PDF files on-the-fly
+ii  php-xml                           1:7.0+49                          all          DOM, SimpleXML, WDDX, XML, and XSL module for PHP [default]
+ii  php7.0                            7.0.27-0+deb9u1                   all          server-side, HTML-embedded scripting language (metapackage)
+ii  php7.0-bz2                        7.0.27-0+deb9u1                   armhf        bzip2 module for PHP
+ii  php7.0-cgi                        7.0.27-0+deb9u1                   armhf        server-side, HTML-embedded scripting language (CGI binary)
+ii  php7.0-cli                        7.0.27-0+deb9u1                   armhf        command-line interpreter for the PHP scripting language
+ii  php7.0-common                     7.0.27-0+deb9u1                   armhf        documentation, examples and common module for PHP
+ii  php7.0-curl                       7.0.27-0+deb9u1                   armhf        CURL module for PHP
+ii  php7.0-json                       7.0.27-0+deb9u1                   armhf        JSON module for PHP
+ii  php7.0-mbstring                   7.0.27-0+deb9u1                   armhf        MBSTRING module for PHP
+ii  php7.0-mysql                      7.0.27-0+deb9u1                   armhf        MySQL module for PHP
+ii  php7.0-opcache                    7.0.27-0+deb9u1                   armhf        Zend OpCache module for PHP
+ii  php7.0-readline                   7.0.27-0+deb9u1                   armhf        readline module for PHP
+ii  php7.0-soap                       7.0.27-0+deb9u1                   armhf        SOAP module for PHP
+ii  php7.0-sqlite3                    7.0.27-0+deb9u1                   armhf        SQLite3 module for PHP
+ii  php7.0-xml                        7.0.27-0+deb9u1                   armhf        DOM, SimpleXML, WDDX, XML, and XSL module for PHP
+ii  php7.0-zip                        7.0.27-0+deb9u1                   armhf        Zip module for PHP
+ii  pinentry-curses                   1.0.0-2                           armhf        curses-based PIN or pass-phrase entry dialog for GnuPG
+ii  pkg-config                        0.29-4                            armhf        manage compile and link flags for libraries
+ii  plymouth                          0.9.2-4+rpi1                      armhf        boot animation, logger and I/O multiplexer
+ii  poppler-data                      0.4.7-8                           all          encoding data for the poppler PDF rendering library
+ii  procps                            2:3.3.12-3                        armhf        /proc file system utilities
+ii  psmisc                            22.21-2.1                         armhf        utilities that use the proc file system
+ii  python                            2.7.13-2                          armhf        interactive high-level object-oriented language (default version)
+ii  python-apt-common                 1.1.0~beta5                       all          Python interface to libapt-pkg (locales)
+ii  python-bluez                      0.22-1                            armhf        Python wrappers around BlueZ for rapid bluetooth development
+ii  python-bs4                        4.5.3-1                           all          error-tolerant HTML parser for Python
+ii  python-chardet                    2.3.0-2                           all          universal character encoding detector for Python2
+ii  python-crypto                     2.6.1-7                           armhf        cryptographic algorithms and protocols for Python
+ii  python-dnspython                  1.15.0-1                          all          DNS toolkit for Python
+ii  python-html5lib                   0.999999999-1                     all          HTML parser/tokenizer based on the WHATWG HTML5 specification
+ii  python-ldb                        2:1.1.27-1                        armhf        Python bindings for LDB
+ii  python-lxml                       3.7.1-1                           armhf        pythonic binding for the libxml2 and libxslt libraries
+ii  python-minimal                    2.7.13-2                          armhf        minimal subset of the Python language (default version)
+ii  python-mysql.connector            2.1.6-1                           all          pure Python implementation of MySQL Client/Server protocol
+ii  python-ntdb                       1.0-9                             armhf        Python bindings for NTDB
+ii  python-pkg-resources              33.1.1-1                          all          Package Discovery and Resource Access using pkg_resources
+ii  python-samba                      2:4.5.12+dfsg-2+deb9u1            armhf        Python bindings for Samba
+ii  python-six                        1.10.0-3                          all          Python 2 and 3 compatibility library (Python 2 interface)
+ii  python-talloc                     2.1.8-1                           armhf        hierarchical pool based memory allocator - Python bindings
+ii  python-tdb                        1.3.11-2                          armhf        Python bindings for TDB
+ii  python-webencodings               0.5-2                             all          Python implementation of the WHATWG Encoding standard
+ii  python2.7                         2.7.13-2+deb9u2                   armhf        Interactive high-level object-oriented language (version 2.7)
+ii  python2.7-minimal                 2.7.13-2+deb9u2                   armhf        Minimal subset of the Python language (version 2.7)
+ii  python3                           3.5.3-1                           armhf        interactive high-level object-oriented language (default python3 version)
+ii  python3-apt                       1.1.0~beta5                       armhf        Python 3 interface to libapt-pkg
+ii  python3-minimal                   3.5.3-1                           armhf        minimal subset of the Python language (default python3 version)
+ii  python3-pkg-resources             33.1.1-1                          all          Package Discovery and Resource Access using pkg_resources
+ii  python3.5                         3.5.3-1                           armhf        Interactive high-level object-oriented language (version 3.5)
+ii  python3.5-minimal                 3.5.3-1                           armhf        Minimal subset of the Python language (version 3.5)
+ii  readline-common                   7.0-3                             all          GNU readline and history libraries, common files
+ii  rename                            0.20-4                            all          Perl extension for renaming multiple files
+ii  rlwrap                            0.42-3                            armhf        readline feature command line wrapper
+ii  rpcbind                           0.2.3-0.6                         armhf        converts RPC program numbers into universal addresses
+ii  rsync                             3.1.2-1+deb9u1                    armhf        fast, versatile, remote (and local) file-copying tool
+ii  rsyslog                           8.24.0-1                          armhf        reliable system and kernel logging daemon
+ii  rtmpdump                          2.4+20151223.gitfa8646d.1-1       armhf        small dumper for media content streamed over the RTMP protocol
+ii  samba                             2:4.5.12+dfsg-2+deb9u1            armhf        SMB/CIFS file, print, and login server for Unix
+ii  samba-common                      2:4.5.12+dfsg-2+deb9u1            all          common files used by both the Samba server and client
+ii  samba-common-bin                  2:4.5.12+dfsg-2+deb9u1            armhf        Samba common files used by both the server and the client
+ii  samba-dsdb-modules                2:4.5.12+dfsg-2+deb9u1            armhf        Samba Directory Services Database
+ii  samba-vfs-modules                 2:4.5.12+dfsg-2+deb9u1            armhf        Samba Virtual FileSystem plugins
+ii  sed                               4.4-1                             armhf        GNU stream editor for filtering/transforming text
+ii  sensible-utils                    0.0.9+deb9u1                      all          Utilities for sensible alternative selection
+ii  sgml-base                         1.29                              all          SGML infrastructure and SGML catalog file support
+ii  shared-mime-info                  1.8-1                             armhf        FreeDesktop.org shared MIME database and spec
+ii  socat                             1.7.3.1-2+deb9u1                  armhf        multipurpose relay for bidirectional data transfer
+ii  spawn-fcgi                        1.6.4-1                           armhf        FastCGI process spawner
+ii  splay                             0.9.5.2-14                        armhf        Sound player for MPEG-1,2 layer 1,2,3
+ii  sqlite                            2.8.17-14                         armhf        command line interface for SQLite 2
+ii  sqlite3                           3.16.2-5+deb9u1                   armhf        Command line interface for SQLite 3
+ii  ssh                               1:7.4p1-10+deb9u2                 all          secure shell client and server (metapackage)
+ii  ssl-cert                          1.0.39                            all          simple debconf wrapper for OpenSSL
+ii  ssmtp                             2.64-8                            armhf        extremely simple MTA to get mail off the system to a mail hub
+ii  startpar                          0.59-3.1                          armhf        run processes in parallel and multiplex their output
+ii  strace                            4.15-2                            armhf        System call tracer
+ii  sudo                              1.8.19p1-2.1                      armhf        Provide limited super user privileges to specific users
+ii  systemd                           232-25+deb9u1                     armhf        system and service manager
+ii  systemd-sysv                      232-25+deb9u1                     armhf        system and service manager - SysV links
+ii  sysv-rc                           2.88dsf-59.9                      all          System-V-like runlevel change mechanism
+ii  sysvinit-utils                    2.88dsf-59.9                      armhf        System-V-like utilities
+ii  tar                               1.29b-1.1                         armhf        GNU version of the tar archiving utility
+ii  tasksel                           3.39                              all          tool for selecting tasks for installation on Debian systems
+ii  tasksel-data                      3.39                              all          official tasks used for installation of Debian systems
+ii  tcl8.6                            8.6.6+dfsg-1                      armhf        Tcl (the Tool Command Language) v8.6 - shell
+ii  tcpd                              7.6.q-26                          armhf        Wietse Venema's TCP wrapper utilities
+ii  tcpdump                           4.9.2-1~deb9u1                    armhf        command-line network traffic analyzer
+ii  tdb-tools                         1.3.11-2                          armhf        Trivial Database - bundled binaries
+ii  tk8.6                             8.6.6-1                           armhf        Tk toolkit for Tcl and X11 v8.6 - windowing shell
+ii  traceroute                        1:2.1.0-2                         armhf        Traces the route taken by packets over an IPv4/IPv6 network
+ii  triggerhappy                      0.5.0-1                           armhf        global hotkey daemon for Linux
+ii  tzdata                            2017c-0+deb9u1                    all          time zone and daylight-saving time data
+ii  ucf                               3.0036                            all          Update Configuration File(s): preserve user changes to config files
+ii  udev                              232-25+deb9u1                     armhf        /dev/ and hotplug management daemon
+ii  unattended-upgrades               0.93.1+nmu1                       all          automatic installation of security upgrades
+ii  unzip                             6.0-21                            armhf        De-archiver for .zip files
+ii  update-inetd                      4.44                              all          inetd configuration file updater
+ii  usb-modeswitch                    2.5.0+repack0-1                   armhf        mode switching tool for controlling "flip flop" USB devices
+ii  usb-modeswitch-data               20170120-1                        all          mode switching data for usb-modeswitch
+ii  usbutils                          1:007-4                           armhf        Linux USB utilities
+ii  util-linux                        2.29.2-1                          armhf        miscellaneous system utilities
+ii  v4l-utils                         1.12.3-1                          armhf        Collection of command line video4linux utilities
+ii  vim                               2:8.0.0197-4+deb9u1               armhf        Vi IMproved - enhanced vi editor
+ii  vim-common                        2:8.0.0197-4+deb9u1               all          Vi IMproved - Common files
+ii  vim-runtime                       2:8.0.0197-4+deb9u1               all          Vi IMproved - Runtime files
+ii  vim-tiny                          2:8.0.0197-4+deb9u1               armhf        Vi IMproved - enhanced vi editor - compact version
+ii  vsftpd                            3.0.3-8                           armhf        lightweight, efficient FTP server written for security
+ii  wget                              1.18-5+deb9u1                     armhf        retrieves files from the web
+ii  whiptail                          0.52.19-1                         armhf        Displays user-friendly dialog boxes from shell scripts
+ii  wireless-regdb                    2016.06.10-1                      all          wireless regulatory database
+ii  wireless-tools                    30~pre9-12                        armhf        Tools for manipulating Linux Wireless Extensions
+ii  wpasupplicant                     2:2.4-1+deb9u1                    armhf        client support for WPA and WPA2 (IEEE 802.11i)
+ii  x11-common                        1:7.7+19                          all          X Window System (X.Org) infrastructure
+ii  x11-utils                         7.7+3                             armhf        X11 utilities
+ii  x11-xserver-utils                 7.7+7                             armhf        X server utilities
+ii  xauth                             1:1.0.9-1                         armhf        X authentication utility
+ii  xbitmaps                          1.1.1-2                           all          Base X bitmaps
+ii  xdg-user-dirs                     0.15-2                            armhf        tool to manage well known user directories
+ii  xdg-utils                         1.1.1-1                           all          desktop integration utilities from freedesktop.org
+ii  xkb-data                          2.19-1+deb9u1                     all          X Keyboard Extension (XKB) configuration data
+ii  xml-core                          0.17                              all          XML infrastructure and XML catalog file support
+ii  xterm                             327-2                             armhf        X terminal emulator
+ii  xxd                               2:8.0.0197-4+deb9u1               armhf        tool to make (or reverse) a hex dump
+ii  xz-utils                          5.2.2-1.2                         armhf        XZ-format compression utilities
+ii  youtube-dl                        2017.05.18.1-1                    all          downloader of videos from YouTube and other sites
+ii  zip                               3.0-11                            armhf        Archiver for .zip files
+ii  smbclient                         2:4.5.12+dfsg-2+deb9u1            armhf        command-line SMB/CIFS clients for Unix
+ii  autofs                            5.1.2-1                           armhf        kernel-based automounter for Linux
+ii  libfile-find-rule-perl            0.34-1                            all          module to search for files based on rules


### PR DESCRIPTION
this is the cleaned up packages list for the amd64 architecture on Debian. I think this should be part of the repo. What was changed based on the original packages.txt
- removed pacakges which and in ":armhf" because they cannot be found on this architecture
- removed raspberry specific pacakges: 
  - bluez-firmware
  - cpp-4.9
  - firmware-atheros
  - firmware-brcm80211
  - firmware-libertas
  - firmware-misc-nonfree
  - firmware-realtek
  - libpostproc52
  - libraspberrypi-bin
  - libraspberrypi-dev
  - libraspberrypi-doc
  - libraspberrypi0
  - libsigc++-1.2-5c2
  - mountall
  - pi-bluetooth
  - python-rpi.gpio
  - raspberrypi-bootloader
  - raspberrypi-kernel
  - raspberrypi-net-mods
  - raspberrypi-sys-mods
  - raspbian-archive-keyring
  - raspi-config
  - raspi-copies-and-fills
  - rpi-update
- added libfile-find-rule-perl