### PR TITLE
Fix vim "E474: Invalid argument" error

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,3 +1,5 @@
+set encoding=utf-8
+scriptencoding utf-8
 set ai nocp digraph ek hid   ru sc vb wmnu   noeb noet nosol
 set bs=2 fo=cqrt ls=2 shm=at ww=<,>,h,l mouse=r
 set comments=b:#,:%,n:>


### PR DESCRIPTION
This fixes #1483 

.vimrc is missing an encoding setting

