### PR TITLE
Fix JSON.parse error for certain MQTT subscription filter expressions

### DIFF
--- a/templates/system/mqtt-gateway.html
+++ b/templates/system/mqtt-gateway.html
@@ -18,7 +18,7 @@
 
 <!-- RAW Config -->
 <div style="display:none">
-	<div id="mqttconfig"><TMPL_VAR JSONCONFIG></div>
+	<div id="mqttconfig"><TMPL_VAR JSONCONFIG ESCAPE=HTML></div>
 	<div id="udpinportconfig"><TMPL_VAR UDPINPORT></div>
 	<div id="extpluginsettings"><TMPL_VAR EXTPLUGINSETTINGS></div>
 	<div id="Uselocalbroker"><TMPL_VAR USELOCALBROKER></div>


### PR DESCRIPTION
Fixes #1487

Escape the tmpl_var for html so it can be parsed as JSON without error.

I tested it successfully in Firefox and Chromium.
Tested on Loxberry v3.0.1.2 on DietPi v9.4.2 (Proxmox VM)