### PR TITLE
fix(plugins): SemVer prereleases for autoupdate + UI compare

### DIFF
--- a/libs/perllib/LoxBerry/PluginSemVer.pm
+++ b/libs/perllib/LoxBerry/PluginSemVer.pm
@@ -1,0 +1,194 @@
+# Lightweight SemVer 2 comparisons for plugin AUTOUPDATE/version strings,
+# compatible with hyphenated prerelease labels (e.g. 1.4.1-beta.2).
+#
+# Fallback: Perl "lax" version objects (version.pm) when strings do not
+# match SemVer normalization used here — keeps older plugin versions working.
+
+package LoxBerry::PluginSemVer;
+
+use strict;
+use warnings;
+
+use version;
+
+use base 'Exporter';
+our @EXPORT_OK = qw( cmp_versions has_prerelease parse_semver_trim version_defined comparable );
+
+##########################################################################
+sub trim {
+	my ($s) = @_;
+	return '' unless defined $s;
+	for ($s) {
+		s/^\s+//;
+		s/\s+$//;
+	}
+	return $s;
+}
+
+sub _strip_v_prefix {
+	my ($s) = @_;
+	$s =~ s/^v//i;
+	return $s;
+}
+
+# Remove SemVer build metadata (+...) for precedence comparison only.
+sub _strip_build_meta {
+	my ($s) = @_;
+	return $s unless defined $s && $s ne '';
+	$s =~ s/\+[^+]*\z//;
+	return $s;
+}
+
+sub version_defined {
+	my ($raw) = @_;
+	return 0 unless defined $raw;
+	return trim($raw) ne '' ? 1 : 0;
+}
+
+# Returns normalized string without leading "v"/whitespace/build metadata when parseable as SemVer.
+sub parse_semver_trim {
+	my ($raw) = @_;
+	my $t = trim($raw);
+	$t =~ s/^v//i;
+	$t = _strip_build_meta($t);
+	return undef if $t eq '';
+	return undef unless _parse_semver($t);
+	return $t;
+}
+
+# SemVer BASE X.Y.Z; patch optional (defaults to 0); optional prerelease after '-'.
+sub _parse_semver {
+	my ($s) = @_;
+	if (
+		$s =~ /\A(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?\z/
+	  )
+	{
+		return {
+			core       => [ int $1, int $2, int $3 ],
+			prerelease => defined $4 ? lc $4 : undef
+		};
+	}
+	if ( $s =~ /\A(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?\z/ ) {
+		return {
+			core       => [ int $1, int $2, 0 ],
+			prerelease => defined $3 ? lc $3 : undef
+		};
+	}
+	return undef;
+}
+
+##########################################################################
+sub _cmp_prerelease_str {
+	my ( $apa, $apb ) = @_;
+
+	my $nea = !( defined $apa && $apa ne '' );
+	my $neb = !( defined $apb && $apb ne '' );
+	return 0  if $nea && $neb;
+	return 1  if !$nea && $neb;
+	return -1 if $nea && !$neb;
+
+	my @sa = split /\./, $apa;
+	my @sb = split /\./, $apb;
+	my $nlen = @sa > @sb ? scalar @sa : scalar @sb;
+	for my $k ( 0 .. $nlen - 1 ) {
+		my $ea = $k <= $#sa;
+		my $eb = $k <= $#sb;
+		return -1 unless $ea;
+		return 1  unless $eb;
+
+		my $xa = $sa[$k];
+		my $xb = $sb[$k];
+		my $nad = $xa =~ /^\d+\z/ ? 1 : 0;
+		my $nbd = $xb =~ /^\d+\z/ ? 1 : 0;
+		if ( $nad && $nbd ) {
+			my $c = int($xa) <=> int($xb);
+			return $c if $c;
+			next;
+		}
+		elsif ( $nad xor $nbd ) {
+			return $nad ? -1 : 1;    # numeric id < non-numeric
+		}
+		else {
+			my $c = $xa cmp $xb;
+			return $c if $c;
+			next;
+		}
+	}
+	return 0;
+}
+
+sub _cmp_semver_hashes {
+	my ( $pa, $pb ) = @_;
+	for my $k ( 0 .. 2 ) {
+		my $c = int( $pa->{core}->[$k] ) <=> int( $pb->{core}->[$k] );
+		return $c if $c;
+	}
+	return _cmp_prerelease_str( $pa->{prerelease}, $pb->{prerelease} );
+}
+
+##########################################################################
+sub has_prerelease {
+	my ($raw) = @_;
+	my $t = parse_semver_trim($raw);
+	return 0 unless defined $t;
+	my $parsed = _parse_semver($t);
+	return 0 unless $parsed;
+	return ( defined $parsed->{prerelease} && $parsed->{prerelease} ne '' ) ? 1 : 0;
+}
+
+sub _can_use_perl_version {
+	my ($tb) = @_;
+	return undef if !defined $tb || $tb eq '';
+	my $slug = trim($tb);
+	$slug = "v$slug" if substr( $slug, 0, 1 ) ne 'v';
+	return undef unless version::is_lax($slug);
+	return $slug;
+}
+
+# Returns -1 (a<b), 0 (equal), +1 (a>b).
+# Fallback: perl version lax compare only when BOTH strings accept version.pm parsing.
+sub cmp_versions {
+	my ( $astra, $bstr ) = @_;
+
+	return 0 if !defined $astra || !defined $bstr;
+
+	my $ta = _strip_build_meta( _strip_v_prefix( trim($astra) ) );
+	my $tb = _strip_build_meta( _strip_v_prefix( trim($bstr) ) );
+	return -1 if $ta eq '';
+	return 1 if $tb eq '';
+
+	my $psa = _parse_semver($ta);
+	my $psb = _parse_semver($tb);
+	if ($psa && $psb) {
+		return _cmp_semver_hashes( $psa, $psb );
+	}
+
+	my $la = _can_use_perl_version($ta);
+	my $lb = _can_use_perl_version($tb);
+
+	if ( defined $la && defined $lb ) {
+		my $vga = eval { version->parse($la) };
+		my $vgb = eval { version->parse($lb) };
+		if ($vga && $vgb) {
+			return $vga <=> $vgb;
+		}
+	}
+
+	return 0;
+}
+
+# True when Version string compares with cmp_versions (-1,+1 acceptable)
+sub comparable {
+	my ($v) = @_;
+	return 0 unless version_defined($v);
+	my $tb = trim($v);
+	my $psa = _parse_semver(
+		_strip_build_meta( _strip_v_prefix($tb) ) );
+	return 1 if $psa;
+
+	my $slug = trim($tb);
+	$slug = "v$slug" if substr( $slug, 0, 1 ) ne 'v';
+	return version::is_lax($slug) ? 1 : 0;
+}
+
+1;

--- a/libs/perllib/t/plugin_semver.t
+++ b/libs/perllib/t/plugin_semver.t
@@ -1,0 +1,24 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use lib "$FindBin::Bin/..";
+
+use_ok 'LoxBerry::PluginSemVer' or BAIL_OUT('cannot load PluginSemVer');
+
+ok( LoxBerry::PluginSemVer->can('cmp_versions'),    'cmp_versions available' );
+ok( LoxBerry::PluginSemVer->can('has_prerelease'),  'has_prerelease available' );
+ok( LoxBerry::PluginSemVer->can('comparable'),      'comparable available' );
+
+my $cmp = \&LoxBerry::PluginSemVer::cmp_versions;
+
+is( $cmp->( '1.4.1-beta.2', '1.4.1-beta.4' ), -1, 'beta.2 older than beta.4' );
+is( $cmp->( '1.4.1-beta.4', '1.4.1-beta.2' ),  1, 'beta.4 newer than beta.2' );
+is( $cmp->( '1.4.1',        '1.4.1-beta.4' ),  1, 'release newer than prerelease (same BASE)' );
+is( $cmp->( '1.4.1-beta.4', '1.4.1' ),        -1, 'prerelease older than release' );
+
+ok( LoxBerry::PluginSemVer::comparable('1.4.1-beta.2'), 'semver prerelease comparable' );
+ok( LoxBerry::PluginSemVer::has_prerelease('1.4.1-beta.2'), 'detect prerelease suffix' );
+
+done_testing();

--- a/sbin/pluginsupdate.pl
+++ b/sbin/pluginsupdate.pl
@@ -23,10 +23,10 @@ use LoxBerry::System;
 use LoxBerry::Web;
 use LoxBerry::Log;
 use LoxBerry::System::PluginDB;
+use LoxBerry::PluginSemVer qw( cmp_versions has_prerelease comparable );
 
 use strict;
 use warnings;
-use version;
 
 
 ##########################################################################
@@ -34,7 +34,7 @@ use version;
 ##########################################################################
 
 # Version of this script
-my $scriptversion="3.0.0.1";
+my $scriptversion="3.1.0.0";
 
 # Global vars
 my $update_path = '/tmp/pluginsupdate';
@@ -47,10 +47,8 @@ my $prereleasefile = "/tmp/pluginsupdate/prerelease.cfg";
 my $prereleasecfg;
 my $prereleasearchive;
 my $prereleaseinfo;
-my $prereleasever;
 my $releasefile = "/tmp/pluginsupdate/release.cfg";
 my $releasecfg;
-my $releasever;
 my $releasearchive;
 my $releaseinfo;
 my $resp;
@@ -109,7 +107,7 @@ foreach my $arg(@ARGV) {
 foreach (@plugins) {
 
 	my $notify;
-	my $currentver;
+	my $currentver_str;
 	my $release;
 	my $prerelease;
 	my $pid;
@@ -121,7 +119,7 @@ foreach (@plugins) {
 
 
 	$pid = $_->{PLUGINDB_MD5_CHECKSUM};
-	$currentver = $_->{PLUGINDB_VERSION};
+	$currentver_str = trim( $_->{PLUGINDB_VERSION} );
 	$plugintitle = $_->{PLUGINDB_TITLE};
 	$pluginname = $_->{PLUGINDB_NAME};
 	$pluginmd5 = $_->{PLUGINDB_MD5_CHECKSUM};
@@ -130,15 +128,13 @@ foreach (@plugins) {
 	LOGINF "$pluginname: Found plugin $_->{PLUGINDB_TITLE}.";
 
 	#
-	# Checks
+	# Checks — SemVer prereleases (-beta.N) plus legacy Perl lax versions.
 	#
-	if ( !version::is_lax(vers_tag($currentver)) ) {
-		LOGCRIT "$pluginname: Cannot check plugin's version number. Is this a real version number? $currentver. Skipping...";
+	if ( !comparable($currentver_str) ) {
+		LOGCRIT "$pluginname: Cannot check plugin's version number. Is this a real version number? $currentver_str. Skipping...";
 		next;
-	} else {
-		$currentver = version->parse(vers_tag($currentver));
-		LOGINF "$pluginname: Current version is: $currentver";
 	}
+	LOGINF "$pluginname: Current version is: $currentver_str";
 	
 	if (!$_->{PLUGINDB_AUTOUPDATE}) {
 		LOGINF "$pluginname: Provide no automatic updates. Skipping.";
@@ -189,162 +185,182 @@ foreach (@plugins) {
 	}
 
 	#
-	# Check for a release
+	# Fetch release.cfg / prerelease.cfg (SemVer prereleases + legacy lax versions)
 	#
-	
 	my $installtype;
-	
-	if ( ($release || $notify) && $endpointrelease ) {
+
+	my ( $releasever_str, $releasearchive, $releaseinfo ) =
+	  ( undef, undef, undef );
+	my $release_cmp_ok = 0;
+
+	my ( $prereleasever_str, $prereleasearchive, $prereleaseinfo ) =
+	  ( undef, undef, undef );
+	my $prerelease_cmp_ok = 0;
+
+	if ( ( $release || $notify ) && $endpointrelease ) {
 
 		LOGINF "$pluginname: Requesting release file from $endpointrelease";
 		$resp = `$bins->{CURL} -q --connect-timeout 10 --max-time 60 --retry 5 --raw -LfksSo $releasefile $endpointrelease  2>&1`;
-		if ($? ne 0) {
+		if ( $? ne 0 ) {
 			LOGCRIT "$pluginname: Could not fetch RELEASE file. Error: $resp Skipping this plugin...";
 			next;
-		} else {
-			LOGOK "$pluginname: Release file fetched.";
-			eval {
-				$releasecfg = new Config::Simple("$releasefile");
-			};
-			if ($@) {
-				LOGCRIT "$pluginname: Fetched release.cfg is not a valid release file. Please report to the plugin author.";
-				next;
-			}
-			$releasever = $releasecfg->param("AUTOUPDATE.VERSION");
-			$releasearchive = $releasecfg->param("AUTOUPDATE.ARCHIVEURL");
-			$releaseinfo = $releasecfg->param("AUTOUPDATE.INFOURL");
+		}
+		LOGOK "$pluginname: Release file fetched.";
+		eval { $releasecfg = new Config::Simple("$releasefile"); };
+		if ($@) {
+			LOGCRIT "$pluginname: Fetched release.cfg is not a valid release file. Please report to the plugin author.";
+			next;
+		}
+		$releasever_str = trim( $releasecfg->param("AUTOUPDATE.VERSION") );
+		$releasearchive = $releasecfg->param("AUTOUPDATE.ARCHIVEURL");
+		$releaseinfo    = $releasecfg->param("AUTOUPDATE.INFOURL");
 
-			if ( version::is_lax(vers_tag($releasever)) ) {
-				$releasever = version->parse(vers_tag($releasever));
-				LOGINF "$pluginname: Found release version: $releasever";
-			} else {
-				LOGCRIT "$pluginname: Cannot check release version number. Is this a real version number?";
-			}
-
-			if ( $releasever > $currentver ) {
+		if ( !$releasever_str || !comparable($releasever_str) ) {
+			LOGCRIT "$pluginname: Cannot check release version number. Is this a real version number?";
+		}
+		else {
+			LOGINF "$pluginname: Found release version: $releasever_str";
+			if ( cmp_versions( $releasever_str, $currentver_str ) > 0 ) {
 				LOGINF "$pluginname: Release version is newer than current installed version.";
-				$installversion = $releasever;
-				$installtype = "release";
-				if ( !$notify ) {
-					$installarchive = $releasearchive;
-				} else {
-					my @notifications = get_notifications( 'plugininstall', "lastnotified-rel-$pluginname");
-					my $last_notified_version;
-					$last_notified_version = $notifications[0]->{version} if ($notifications[0]);
-					delete_notifications('plugininstall', "lastnotified-rel-$pluginname");
-					my %notification = (
-								PACKAGE => "plugininstall",
-								NAME => "lastnotified-rel-$pluginname",
-								MESSAGE => "This helper notification keeps track of last notified release of $plugintitle",
-								SEVERITY => 7,
-								pluginname => $pluginname,
-								pluginmd5 => $pluginmd5,
-								version => "$releasever",
-								installarchive => "$releasearchive",
-								releaseinfo => $releaseinfo,
-								type => "release",
-								LINK => $releaseinfo
-					);
-					LoxBerry::Log::notify_ext( \%notification );
-					if ($last_notified_version && $last_notified_version eq "$releasever") {
-						LOGOK "$pluginname: Skipping notification because version has already been notified.";
-					} elsif ($checkonly) {
-						LOGINF "$pluginname: Skipping notification because of --checkonly parameter. This is an interactive call.";
-					} elsif ($_->{PLUGINDB_AUTOUPDATE} eq "1") {
-						LOGINF "$pluginname: Skipping notification because automatic updates and notifys are disabled.";
-					} else {
-						$message = "$plugintitle - $SL{'PLUGININSTALL.UI_NOTIFY_AUTOINSTALL_RELEASE_AVAILABLE'} $installversion\n";
-						$message .= $SL{'PLUGININSTALL.UI_NOTIFY_AUTOINSTALL_INSTRUCTION'};
-						notify ( "plugininstall", "$pluginname", $message);
-						LOGINF "$pluginname: Notification saved.";
-					}
-				}
-
-			} else {
-				# Installed version is equal or newer. Helper notification can be deleted.
-				LOGINF "$pluginname: Release version is not newer than installed version.";
-				delete_notifications('plugininstall', "lastnotified-rel-$pluginname");
+				$release_cmp_ok = 1;
 			}
-
+			else {
+				LOGINF "$pluginname: Release version is not newer than installed version.";
+				delete_notifications( 'plugininstall', "lastnotified-rel-$pluginname" );
+			}
 		}
 	}
-	
-	#
-	# Check for a prerelease
-	#
-	if ( ($prerelease || $notify) && $endpointprerelease ) {
+
+	if ( ( $prerelease || $notify ) && $endpointprerelease ) {
 
 		LOGINF "$pluginname: Requesting prerelease from $endpointprerelease";
-
 		$resp = `$bins->{CURL} -q --connect-timeout 10 --max-time 60 --retry 5 --raw -LfksSo $releasefile $endpointprerelease  2>&1`;
-		if ($? ne 0) {
+		if ( $? ne 0 ) {
 			LOGCRIT "$pluginname: Could not fetch PRERELEASE file. Error: $resp Skipping this plugin...";
 			next;
-		} else {
-			LOGOK "$pluginname: Prerelease file fetched.";
-			eval {
-				$prereleasecfg = new Config::Simple("$releasefile");
-			};
-			if ($@) {
-				LOGCRIT "$pluginname: Fetched prerelease.cfg is not a valid release file. Please report to the plugin author.";
-				next;
-			}
-			$prereleasever = $prereleasecfg->param("AUTOUPDATE.VERSION");
-			$prereleasearchive = $prereleasecfg->param("AUTOUPDATE.ARCHIVEURL");
-			$prereleaseinfo = $prereleasecfg->param("AUTOUPDATE.INFOURL");
-
-			if ( version::is_lax(vers_tag($prereleasever)) ) {
-				$prereleasever = version->parse(vers_tag($prereleasever));
-				LOGINF "$pluginname: Found prerelease version: $prereleasever";
-			} else {
-				LOGCRIT "$pluginname: Cannot check prerelease version number. Is this a real version number?";
-			}
-
-			if ( $prereleasever > $releasever && $prereleasever > $currentver) {
-				LOGINF "$pluginname: Prerelease version is newer than release version, and newer than installed version.";
-				$installversion = $prereleasever;
-				$installtype = "prerelease";
-				if ( !$notify ) {
-					$installarchive = $prereleasearchive;
-				} else {
-					my @notifications = get_notifications( 'plugininstall', "lastnotified-prerel-$pluginname");
-					my $last_notified_version;
-					$last_notified_version = $notifications[0]->{version} if ($notifications[0]);
-					delete_notifications('plugininstall', "lastnotified-prerel-$pluginname");
-					my %notification = (
-								PACKAGE => "plugininstall",
-								NAME => "lastnotified-prerel-$pluginname",
-								MESSAGE => "This helper notification keeps track of last notified pre-release of $plugintitle",
-								SEVERITY => 7,
-								pluginname => $pluginname,
-								pluginmd5 => $pluginmd5,
-								version => "$prereleasever",
-								installarchive => "$prereleasearchive",
-								releaseinfo => $prereleaseinfo,
-								type => "prerelease",
-								LINK => $prereleaseinfo
-						);
-					LoxBerry::Log::notify_ext( \%notification );
-					if ($last_notified_version && $last_notified_version eq "$prereleasever") {
-						LOGOK "$pluginname: Skipping notification because version has already been notified.";
-					} elsif ($checkonly) {
-						LOGINF "$pluginname: Skipping notification because of --checkonly parameter. This is an interactive call.";
-					} elsif ($_->{PLUGINDB_AUTOUPDATE} eq "1") {
-						LOGINF "$pluginname: Skipping notification because automatic updates and notifys are disabled.";
-					} else {
-						$message = "$plugintitle - $SL{'PLUGININSTALL.UI_NOTIFY_AUTOINSTALL_PRERELEASE_AVAILABLE'} $installversion\n";
-						$message .= $SL{'PLUGININSTALL.UI_NOTIFY_AUTOINSTALL_INSTRUCTION'};
-						notify ( "plugininstall", "$pluginname", $message);
-						LOGINF "$pluginname: Notification saved.";
-					}
-				}
-			} else {
-				LOGINF "$pluginname: Prerelease version is not newer than release version.";
-				delete_notifications('plugininstall', "lastnotified-prerel-$pluginname");
-			}
-
 		}
+		LOGOK "$pluginname: Prerelease file fetched.";
+		eval { $prereleasecfg = new Config::Simple("$releasefile"); };
+		if ($@) {
+			LOGCRIT "$pluginname: Fetched prerelease.cfg is not a valid release file. Please report to the plugin author.";
+			next;
+		}
+		$prereleasever_str = trim( $prereleasecfg->param("AUTOUPDATE.VERSION") );
+		$prereleasearchive = $prereleasecfg->param("AUTOUPDATE.ARCHIVEURL");
+		$prereleaseinfo    = $prereleasecfg->param("AUTOUPDATE.INFOURL");
 
+		if ( !$prereleasever_str || !comparable($prereleasever_str) ) {
+			LOGCRIT "$pluginname: Cannot check prerelease version number. Is this a real version number?";
+		}
+		else {
+			LOGINF "$pluginname: Found prerelease version: $prereleasever_str";
+			if ( cmp_versions( $prereleasever_str, $currentver_str ) > 0 ) {
+				LOGINF "$pluginname: Prerelease version is newer than current installed version.";
+				$prerelease_cmp_ok = 1;
+			}
+			else {
+				LOGINF "$pluginname: Prerelease version is not newer than installed version.";
+				delete_notifications( 'plugininstall', "lastnotified-prerel-$pluginname" );
+			}
+		}
+	}
+
+	my ( $chosen_type, $chosen_ver_str, $chosen_archive, $chosen_info );
+
+	if ( $release_cmp_ok && $prerelease_cmp_ok ) {
+		if (   has_prerelease($currentver_str)
+			&& cmp_versions( $prereleasever_str, $releasever_str ) < 0 )
+		{
+			LOGINF "$pluginname: Preferring newer prerelease (installed version is a prerelease; SemVer ranks it below release).";
+			$chosen_type   = "prerelease";
+			$chosen_ver_str    = $prereleasever_str;
+			$chosen_archive    = $prereleasearchive;
+			$chosen_info       = $prereleaseinfo;
+		}
+		else {
+			LOGINF "$pluginname: Preferring release over prerelease.";
+			$chosen_type   = "release";
+			$chosen_ver_str    = $releasever_str;
+			$chosen_archive    = $releasearchive;
+			$chosen_info       = $releaseinfo;
+		}
+	}
+	elsif ($release_cmp_ok) {
+		$chosen_type    = "release";
+		$chosen_ver_str = $releasever_str;
+		$chosen_archive = $releasearchive;
+		$chosen_info    = $releaseinfo;
+	}
+	elsif ($prerelease_cmp_ok) {
+		$chosen_type    = "prerelease";
+		$chosen_ver_str = $prereleasever_str;
+		$chosen_archive = $prereleasearchive;
+		$chosen_info    = $prereleaseinfo;
+	}
+
+	if ($chosen_type) {
+		$installversion = trim($chosen_ver_str);
+		$installtype = $chosen_type;
+		if ( !$notify ) {
+			$installarchive = $chosen_archive;
+		}
+		else {
+			if ( $chosen_type eq 'release' ) {
+				delete_notifications( 'plugininstall', "lastnotified-prerel-$pluginname" );
+			}
+			else {
+				delete_notifications( 'plugininstall', "lastnotified-rel-$pluginname" );
+			}
+			my $notname =
+			    $chosen_type eq "prerelease"
+			  ? "lastnotified-prerel-$pluginname"
+			  : "lastnotified-rel-$pluginname";
+
+			my @notifications = get_notifications( 'plugininstall', $notname );
+			my $last_notified_version;
+			$last_notified_version = $notifications[0]->{version} if ($notifications[0]);
+
+			delete_notifications( 'plugininstall', $notname );
+			my %notification = (
+				PACKAGE    => "plugininstall",
+				NAME       => $notname,
+				MESSAGE    =>
+				  "Helper notification tracking last notified "
+				  . (
+					$chosen_type eq "prerelease" ? "pre-release" : "release" )
+				  . " of $plugintitle",
+				SEVERITY   => 7,
+				pluginname => $pluginname,
+				pluginmd5  => $pluginmd5,
+				version       => $installversion,
+				installarchive => $chosen_archive,
+				releaseinfo    => $chosen_info,
+				type        => $chosen_type,
+				LINK        => $chosen_info
+			);
+			LoxBerry::Log::notify_ext( \%notification );
+
+			if ($last_notified_version && $last_notified_version eq $installversion) {
+				LOGOK "$pluginname: Skipping notification because version has already been notified.";
+			}
+			elsif ($checkonly) {
+				LOGINF "$pluginname: Skipping notification because of --checkonly parameter. This is an interactive call.";
+			}
+			elsif ( $_->{PLUGINDB_AUTOUPDATE} eq "1" ) {
+				LOGINF "$pluginname: Skipping notification because automatic updates and notifys are disabled.";
+			}
+			else {
+				if ( $chosen_type eq "release" ) {
+					$message = "$plugintitle - $SL{'PLUGININSTALL.UI_NOTIFY_AUTOINSTALL_RELEASE_AVAILABLE'} $installversion\n";
+				}
+				else {
+					$message = "$plugintitle - $SL{'PLUGININSTALL.UI_NOTIFY_AUTOINSTALL_PRERELEASE_AVAILABLE'} $installversion\n";
+				}
+				$message .= $SL{'PLUGININSTALL.UI_NOTIFY_AUTOINSTALL_INSTRUCTION'};
+				notify( "plugininstall", "$pluginname", $message );
+				LOGINF "$pluginname: Notification saved.";
+			}
+		}
 	}
 
 	#
@@ -374,8 +390,8 @@ foreach (@plugins) {
 				LOGINF "$pluginname: Installation routine finished. Check plugin's logfile for details.";
 				$message = "$pluginname - $SL{'PLUGININSTALL.UI_NOTIFY_AUTOINSTALL_DONE'} $installversion";
 				notify ( "plugininstall", "pluginautoupdate", $message);
-				delete_notifications('plugininstall', "lastnotified-prerel-$pluginname") if ($installtype eq "release");
-				delete_notifications('plugininstall', "lastnotified-rel-$pluginname") if ($installtype eq "prerelease" || $installtype eq "release");
+				delete_notifications( 'plugininstall', "lastnotified-rel-$pluginname" );
+				delete_notifications( 'plugininstall', "lastnotified-prerel-$pluginname" );
 			} else {
 				LOGERR "$pluginname: Installation seems to have failed! Please try to manually install the plugin.";
 			}

--- a/templates/system/plugininstall.html
+++ b/templates/system/plugininstall.html
@@ -478,8 +478,73 @@
 	
 
 	
+// SemVer prerelease aware (hyphen identifiers), fallback to dotted-numeric legacy compare.
+
+function semverParseForCompare(raw) {
+	if (raw === undefined || raw === null) return null;
+	var s = String(raw).trim();
+	if (!s.length) return null;
+	if (s.charAt(0).toLowerCase() === 'v') s = s.slice(1);
+	var pb = s.indexOf('+'); if (pb >= 0) s = s.slice(0, pb);
+	var dash = s.indexOf('-');
+	var coreStr = dash >= 0 ? s.slice(0, dash) : s;
+	var preStr = dash >= 0 ? s.slice(dash + 1) : '';
+	var pts = coreStr.split('.');
+	if (!pts.length) return null;
+	if (pts.length > 3) return null;
+	while (pts.length < 3) pts.push('0');
+	if (!/^[0-9]+$/.test(pts[0]) || !/^[0-9]+$/.test(pts[1]) || !/^[0-9]+$/.test(pts[2])) return null;
+	if (preStr && !/^[0-9A-Za-z.-]+$/.test(preStr)) return null;
+	var core = [ parseInt(pts[0], 10), parseInt(pts[1], 10), parseInt(pts[2], 10) ];
+	return { core: core, prerelease: preStr };
+}
+
+function semverCmpPre(ap, bp) {
+	var ea = !(ap !== undefined && ap !== null && ap.length);
+	var eb = !(bp !== undefined && bp !== null && bp.length);
+	if (ea && eb) return 0;
+	if (!ea && eb) return -1;
+	if (ea && !eb) return 1;
+	var sa = ap.split('.');
+	var sb = bp.split('.');
+	var nlen = sa.length > sb.length ? sa.length : sb.length;
+	var k = 0;
+	for (k = 0; k < nlen; k++) {
+		var xa = sa[k]; var xb = sb[k];
+		if (xa === undefined && xb !== undefined) return -1;
+		if (xa !== undefined && xb === undefined) return 1;
+		if (xa === undefined && xb === undefined) break;
+		var nda = /^[0-9]+$/.test(xa); var ndb = /^[0-9]+$/.test(xb);
+		if (nda && ndb) {
+			var ia = parseInt(xa,10), ib = parseInt(xb,10);
+			if (ia !== ib) return ia < ib ? -1 : 1;
+		}
+		else if (nda !== ndb) return nda ? -1 : 1;
+		else {
+			if (xa < xb) return -1;
+			if (xa > xb) return 1;
+		}
+	}
+	return 0;
+}
+
+function semverCmpParsed(a, b) {
+	var k = 0;
+	for (k = 0; k < 3; k++) {
+		if (a.core[k] !== b.core[k]) return a.core[k] < b.core[k] ? -1 : 1;
+	}
+	return semverCmpPre(a.prerelease, b.prerelease);
+}
+
 // 	https://stackoverflow.com/questions/6832596/how-to-compare-software-version-number-using-js-only-number
 function versionCompare(v1, v2, options) {
+	var sx = semverParseForCompare(v1), sy = semverParseForCompare(v2);
+	if (sx && sy) {
+		var c = semverCmpParsed(sx, sy);
+		if (c === 1) return 1;
+		if (c === -1) return -1;
+		return 0;
+	}
     var lexicographical = options && options.lexicographical,
         zeroExtend = options && options.zeroExtend,
         v1parts = v1.split('.'),


### PR DESCRIPTION
Ref:  #1504 

### Real-world plugin

How I use prereleases in my plugin — repo:  
https://github.com/spid3r/loxberry-api-abfall-io  

Root has the usual two-channel setup ([release.cfg](https://github.com/spid3r/loxberry-api-abfall-io/blob/master/release.cfg) / [prerelease.cfg](https://github.com/spid3r/loxberry-api-abfall-io/blob/master/prerelease.cfg)); versions match [GitHub releases](https://github.com/spid3r/loxberry-api-abfall-io/releases) including **pre-releases** (semantic-release). SemVer: everything after the first `-` is prerelease metadata, and `1.4.1` is newer than any `1.4.1-beta.*` (https://semver.org/#spec-item-11). **This PR** wires LoxBerry to that ordering.

### Background

The issue states the user-visible side; short technical version: lax `version.pm` use plus a too-simple prerelease-vs-release gate (and JS that only understands dotted numbers) breaks SemVer prereleases. This PR fixes that without abandoning odd legacy version strings (fallback stays).

### Changes

- **`libs/perllib/LoxBerry/PluginSemVer.pm`** — SemVer compare with fallback when a string isn’t classic SemVer-shaped.
- **`sbin/pluginsupdate.pl`** — uses it for release/prerelease/current; when **both** channels are newer than installed, I follow the line sketched in the issue (if you’re already on a beta and still below the stable in `release.cfg`, stay on the beta train).
- **`templates/system/plugininstall.html`** — SemVer-aware `versionCompare`, legacy numeric path kept.
- **`libs/perllib/t/plugin_semver.t`** — a few `Test::More` orderings.

No new CPAN deps; core `version` plus the small helper.

### Testing

On a test box: drop in those paths, run `pluginsupdate.pl --checkonly` / UI “check for updates”; optionally `prove t/plugin_semver.t` under `perllib` where `Test::More` exists.

### Maintainer input

If **you** prefer a different rule when both release and prerelease are newer than installed (always prefer stable), say so — it’s policy and a small script change plus a note in the issue.

Thanks for the review.

---

**Branch on my fork:** `fix/semver-prerelease-minimal` — intentionally a small diff against `master`.
