### PR TITLE
fix(plugins): SemVer-aware autoupdate and plugin version compare

### DIFF
--- a/libs/perllib/LoxBerry/System.pm
+++ b/libs/perllib/LoxBerry/System.pm
@@ -8,7 +8,7 @@ use Cwd 'abs_path';
 use Carp;
 
 package LoxBerry::System;
-our $VERSION = "3.0.0.7";
+our $VERSION = "3.0.0.8";
 our $DEBUG;
 
 use base 'Exporter';
@@ -60,6 +60,8 @@ our @EXPORT = qw (
 	lox2epoch
 	reboot_required
 	vers_tag
+	plugin_version_compare
+	plugin_version_has_prerelease
 );
 
 ##################################################################
@@ -1501,6 +1503,116 @@ sub vers_tag
 	
 	return $vers;
 
+}
+
+# SemVer 2 precedence for plugin-style versions (classic core + optional prerelease). Build metadata is ignored (SemVer §10).
+# Fallback: lax version.pm when the strings are not classic SemVer-shaped.
+# Returns -1 / 0 / 1 like <=>, or undef if not comparable.
+
+sub plugin_version_compare
+{
+	my ($a_in, $b_in) = @_;
+	return 0 unless defined($a_in) || defined($b_in);
+	return undef unless defined($a_in) && defined($b_in);
+	my $tag_a = lc(LoxBerry::System::trim($a_in));
+	my $tag_b = lc(LoxBerry::System::trim($b_in));
+	$tag_a = vers_tag($tag_a);
+	$tag_b = vers_tag($tag_b);
+
+	my ($maj_a, $min_a, $pat_a, $pre_a, $ok_semver_a) = _plugin_semver_parts($tag_a);
+	my ($maj_b, $min_b, $pat_b, $pre_b, $ok_semver_b) = _plugin_semver_parts($tag_b);
+
+	if ($ok_semver_a && $ok_semver_b) {
+		my $cmaj = int($maj_a) <=> int($maj_b);
+		return $cmaj if $cmaj != 0;
+		my $cmin = int($min_a) <=> int($min_b);
+		return $cmin if $cmin != 0;
+		my $cpat = int($pat_a) <=> int($pat_b);
+		return $cpat if $cpat != 0;
+
+		my $pempty_a = ($pre_a eq '');
+		my $pempty_b = ($pre_b eq '');
+		# Stable (no prerelease) has strictly higher precedence than any prerelease of same MAJOR.MINOR.PATCH (SemVer §11).
+		return -1 if !$pempty_a &&  $pempty_b;
+		return  1 if  $pempty_a && !$pempty_b;
+		return  0 if  $pempty_a &&  $pempty_b;
+
+		return _plugin_semver_prerelease_cmp($pre_a, $pre_b);
+	}
+
+	require version;
+	# Normalize like legacy callers (pluginsupdate/plugininstall path): lax parse uses strings WITH leading v via vers_tag, not stripped.
+	my $parsed_a = vers_tag($tag_a);
+	my $parsed_b = vers_tag($tag_b);
+	return undef unless version::is_lax($parsed_a) && version::is_lax($parsed_b);
+	my $va = eval { version->parse($parsed_a) };
+	my $vb = eval { version->parse($parsed_b) };
+	return undef unless defined $va && defined $vb;
+	return $va <=> $vb;
+}
+
+sub plugin_version_has_prerelease
+{
+	my ($v_in) = @_;
+	return 0 unless defined $v_in && $v_in ne '';
+	my $tag = lc(LoxBerry::System::trim($v_in));
+	$tag = vers_tag($tag);
+	my (undef, undef, undef, $pre, $ok) = _plugin_semver_parts($tag);
+	return ($ok && $pre ne '') ? 1 : 0;
+}
+
+sub _plugin_semver_parts
+{
+	my ($tag) = @_;
+	return (undef, undef, undef, undef, 0) if (!defined($tag) || $tag eq '');
+	my $s = $tag;
+	$s =~ s/^v//;
+	$s =~ s/\+.*\z//;
+	if ($s =~ /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/ ) {
+		my $pre = defined $4 ? $4 : '';
+		return ($1 + 0, $2 + 0, $3 + 0, $pre, 1);
+	}
+	return (undef, undef, undef, undef, 0);
+}
+
+sub _plugin_semver_prerelease_cmp
+{
+	my ($a, $b) = @_;
+	my @pa = split(/\./, $a, -1);
+	my @pb = split(/\./, $b, -1);
+	my $i = 0;
+	while ( 1 ) {
+		my $ida = $pa[$i];
+		my $idb = $pb[$i];
+		if (!defined($ida) && !defined($idb)) {
+			return 0;
+		}
+		if (!defined($ida)) {
+			return -1;
+		}
+		if (!defined($idb)) {
+			return 1;
+		}
+		my $na = ($ida =~ /^\d+$/);
+		my $nb = ($idb =~ /^\d+$/);
+		if ($na && $nb) {
+			no warnings 'numeric';
+			my $wc = ($ida + 0) <=> ($idb + 0);
+			return $wc if $wc != 0;
+		}
+		elsif ($na && !$nb) {
+			return -1;
+		}
+		elsif (!$na && $nb) {
+			return 1;
+		}
+		else {
+			my $ws = ($ida cmp $idb);
+			return $ws if $ws != 0;
+		}
+		$i++;
+	}
+	return 0;
 }
 
 sub bytes_humanreadable

--- a/libs/perllib/t/plugin_semver.t
+++ b/libs/perllib/t/plugin_semver.t
@@ -1,0 +1,395 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use File::Spec;
+
+BEGIN {
+	$ENV{LBHOMEDIR} ||= '/tmp/loxberry_pm_test_home';
+}
+
+# LoxBerry/ lives beside t/ under libs/perllib/
+use lib File::Spec->catdir( $FindBin::Bin, '..' );
+use LoxBerry::System qw(plugin_version_compare plugin_version_has_prerelease);
+
+# Mirrors release vs prerelease pick in sbin/pluginsupdate.pl (sticky when installed is SemVer prerelease).
+sub _pick_channel_like_pluginsupdate {
+	my ($currentver_raw, $rel_verstr, $pre_verstr) = @_;
+
+	my $rel_ok =
+		defined($rel_verstr)
+		&& defined( plugin_version_compare( $rel_verstr, $rel_verstr ) );
+	my $pre_ok =
+		defined($pre_verstr)
+		&& defined( plugin_version_compare( $pre_verstr, $pre_verstr ) );
+
+	my $cmp_rel =
+		$rel_ok ? plugin_version_compare( $rel_verstr, $currentver_raw ) : undef;
+	my $cmp_pre =
+		$pre_ok ? plugin_version_compare( $pre_verstr, $currentver_raw ) : undef;
+
+	my $rel_gt = ( defined($cmp_rel) && $cmp_rel == 1 );
+	my $pre_gt = ( defined($cmp_pre) && $cmp_pre == 1 );
+
+	return undef unless $rel_gt || $pre_gt;
+
+	if ( $rel_gt && $pre_gt && plugin_version_has_prerelease($currentver_raw) ) {
+		return 'prerelease';
+	}
+	if ( $rel_gt && $pre_gt ) {
+		return 'release';
+	}
+	return 'release' if $rel_gt;
+	return 'prerelease';
+}
+
+# shorthand for readable matrices
+sub _cmp {
+	plugin_version_compare( $_[0], $_[1] );
+}
+
+plan tests => 56;
+
+is(
+	plugin_version_compare( '1.4.1', '1.4.1-beta.3' ),
+	1,
+	'release newer than prerelease (same core)'
+);
+is(
+	plugin_version_compare( '1.4.1-beta.3', '1.4.1' ),
+	-1,
+	'prerelease older than release'
+);
+is(
+	plugin_version_compare( '1.4.1-beta.2', '1.4.1-beta.1' ),
+	1,
+	'prerelease dot ordering'
+);
+is(
+	plugin_version_compare( '1.4.1-rc.1', '1.4.1-beta.2' ),
+	1,
+	'RC vs beta (identifier ASCII rule)'
+);
+is( plugin_version_compare( '1.4.1', '1.4.1' ), 0, 'equal release' );
+is(
+	plugin_version_compare( '1.4.1-alpha.1', '1.4.1-alpha.1' ),
+	0,
+	'equal prerelease'
+);
+is(
+	plugin_version_compare( 'v1.4.1', '1.4.1' ),
+	0,
+	'optional v prefix normalized'
+);
+is(
+	plugin_version_compare( '1.4.1+build.x', '1.4.1-beta' ),
+	1,
+	'build metadata ignored'
+);
+
+ok( plugin_version_has_prerelease('1.4.1-beta.1'), 'has_prerelease semver' );
+ok( !plugin_version_has_prerelease('1.4.1'), 'stable has no prerelease' );
+ok(
+	!plugin_version_has_prerelease('1.2.3.4'),
+	'quad not classic SemVer shape for flag'
+);
+
+is(
+	plugin_version_compare( '1.0.0-alpha', '1.0.0-alpha.1' ),
+	-1,
+	'shorter prerelease identifiers lower precedence'
+);
+is(
+	plugin_version_compare( '1.0.0-1', '1.0.0-2' ),
+	-1,
+	'numeric prerelease identifiers'
+);
+
+SKIP: {
+	my $legacy_ok = defined( plugin_version_compare( 'v1.1', 'v1.1.1' ) );
+	skip 'lax version.pm fallback unavailable in this perl', 1 if !$legacy_ok;
+	is(
+		plugin_version_compare( 'v1.1', 'v1.1.1' ),
+		-1,
+		'legacy lax: v1.1 < v1.1.1'
+	);
+}
+
+ok(
+	!defined( plugin_version_compare( '%%%invalid', '%%%bad' ) ),
+	'mutually invalid => undef'
+);
+
+#
+# pluginsupdate-style channel decision (sticky prerelease)
+#
+
+is(
+	_pick_channel_like_pluginsupdate( '1.4.1-beta.1', '2.0.0',
+		'1.5.0-beta.2' ),
+	'prerelease',
+	'pick: both newer + installed is prerelease -> sticky prerelease channel'
+);
+
+is(
+	_pick_channel_like_pluginsupdate( '1.4.9', '2.0.0', '1.5.0-beta.1' ),
+	'release',
+	'pick: both newer + installed stable -> prefer release channel'
+);
+
+is(
+	_pick_channel_like_pluginsupdate( '1.0.0', '1.0.1', undef ),
+	'release',
+	'pick: only release channel beats current'
+);
+
+is(
+	_pick_channel_like_pluginsupdate( '1.0.0', undef, '1.0.1-beta.5' ),
+	'prerelease',
+	'pick: only prerelease channel beats current'
+);
+
+is(
+	_pick_channel_like_pluginsupdate( '1.0.0', undef, '1.0.0-rc.88' ),
+	undef,
+	'pick: prerelease line still older than installed stable same X.Y.Z'
+);
+
+is(
+	_pick_channel_like_pluginsupdate( '2.5.3', '1.99.99', '1.98.99-beta' ),
+	undef,
+	'pick: no bump when upstream behind current'
+);
+
+#
+# Ordering edge cases exercised by pluginsupdate compare calls
+#
+
+is(
+	plugin_version_compare( '1.9.99', '2.0.0-alpha' ),
+	-1,
+	'last 1.x below first 2.0 prerelease'
+);
+
+is(
+	plugin_version_compare( '1.0.0-alpha.1', '1.0.0-alpha.beta' ),
+	-1,
+	'numeric prerelease id loses to alphabetic id (SemVer #11)'
+);
+
+is( plugin_version_compare( '10.0.0', '2.0.0' ), 1,
+	'major numerically 10 > 2' );
+
+foreach my $triple (
+	[ '1.4.1',           '1.4.1-beta.3',  'stable vs pre same core' ],
+	[ '1.0.0-rc.10',     '1.0.0-rc.11',   'incremental prereleases' ],
+	[ '99.255.65535-rc', '99.255.65535',  'rc below same release triple' ]
+	)
+{
+	my ( $lhs, $rhs, $descr ) = @$triple;
+
+	my $ab = plugin_version_compare( $lhs, $rhs );
+	my $ba = plugin_version_compare( $rhs, $lhs );
+	SKIP: {
+		skip "$descr incomparable either way", 1
+			if !( defined($ab) && defined($ba) );
+		is( $ba, -$ab, "antisymm: $descr" );
+	}
+}
+
+#
+# Stage 1: dense compare matrix (pure SemVer + lax edge spot checks)
+#
+
+is(
+	_cmp( '1.4.11', '1.4.12' ),
+	-1,
+	'matrix compare: PATCH within same MINOR'
+);
+is(
+	_cmp( '1.99.998', '99.998.997' ),
+	-1,
+	'matrix compare: MAJOR dominates large digit triples'
+);
+is(
+	_cmp( '0.0.555', '42.4242.4242' ),
+	-1,
+	'matrix compare: leap from tiny 0.x to large MAJOR line'
+);
+is(
+	_cmp( '1.0.55', '10.55.56' ),
+	-1,
+	'matrix compare: MAJOR numeric order (never string collation)'
+);
+
+is(
+	_cmp( '1.8.333-beta.900', '2.11.444-alpha.1' ),
+	-1,
+	'matrix compare: older triple beta loses vs newer triple alpha across MAJOR'
+);
+
+is(
+	_cmp( '3.1415.927', '10.71828.281' ),
+	-1,
+	'matrix compare: multi-digit PATCH as integers'
+);
+
+is(
+	_cmp( '1.0.0-beta.11', '1.0.1-beta.9' ),
+	-1,
+	'matrix compare: patched release beats ornate prerelease on prior PATCH'
+);
+
+is(
+	_cmp( '1.0.0-x', '1.0.1-x.y' ),
+	-1,
+	'matrix compare: older PATCH + short tag loses to PATCH bump + richer tag'
+);
+
+is(
+	_cmp( '81.928.848', 'V81.928.848' ),
+	0,
+	'matrix compare: leading-V case normalisation (SemVer lane)'
+);
+
+is(
+	_cmp( '2.71828.271+metal', 'v2.71828.271+wood' ),
+	0,
+	'matrix compare: build metadata stripped; equal cores'
+);
+
+ok(
+	plugin_version_has_prerelease('1.0.0-0'),
+	'matrix has_prerelease: numeric-only prerelease id 0 counts'
+);
+
+ok(
+	plugin_version_has_prerelease('2.71828.182-alpha.dev.4242-rc0'),
+	'matrix has_prerelease: long dotted prerelease'
+);
+
+SKIP: {
+	skip 'lax single-digit tuple unsupported on this perl', 2
+		unless defined( _cmp( '1', '11' ) );
+	is(
+		_cmp( '1', '11' ),
+		-1,
+		'matrix lax: tiny tuple ordering when fallback defined'
+	);
+	is( _cmp( '11', '1' ), 1,
+		'matrix lax antisym on tiny tuple baseline' );
+}
+
+#
+# Stage 1: pick-policy matrix (broken cfg strings only drop that channel)
+#
+
+is(
+	_pick_channel_like_pluginsupdate(
+		'1.0.0-alpha.4242', '!not-a-real-version-rel!', '2.0.0-rc.881'
+	),
+	'prerelease',
+	'matrix pick: invalid release VERSION self-compare -> prerelease wins alone'
+);
+
+is(
+	_pick_channel_like_pluginsupdate( '314.314.314', '!bad-rel!', '628.627.997' ),
+	'prerelease',
+	'matrix pick: only prerelease survives broken release VERSION'
+);
+
+is(
+	_pick_channel_like_pluginsupdate(
+		'3.4.99', '314.628.981', '!bad-pre!'
+	),
+	'release',
+	'matrix pick: invalid prerelease VERSION -> release-only update'
+);
+
+is(
+	_pick_channel_like_pluginsupdate(
+		'314.717.716', '500.716.716', '500.716.716-beta.joy'
+	),
+	'release',
+	'matrix pick: installed stable prefers release when BOTH channels advertise newer versions'
+);
+
+is(
+	_pick_channel_like_pluginsupdate(
+		'6.717.717-rc.omega', '7.716.716',
+		'6.717.777-alpha.gamma'
+	),
+	'prerelease',
+	'matrix pick: prerelease-installed sticky survives massive stable jump'
+);
+
+is(
+	_pick_channel_like_pluginsupdate( '314.716.716', '!bad-rel!', '!bad-pre!' ),
+	undef,
+	'matrix pick: no update possible when BOTH channel VERSION strings refuse comparison'
+);
+
+#
+# Stage 1: semver transitivity sanity (manual legs + combined)
+#
+
+is(
+	_cmp( '1.0.1', '62.831.853' ),
+	-1,
+	'matrix transit leg A toward large MAJOR'
+);
+
+is(
+	_cmp( '62.831.853', '993.983.743' ),
+	-1,
+	'matrix transit leg B second jump'
+);
+
+is(
+	_cmp( '1.0.1', '993.983.743' ),
+	-1,
+	'matrix transit: direct ordering matches chaining intuition'
+);
+
+#
+# v-prefix, case fold, leading zeros (common real-world cfg noise)
+# Note: SemVer forbids some leading-zero forms; we coerce numerics for plugin compatibility.
+#
+
+is(
+	_cmp( '01.02.03', 'v1.2.3' ),
+	0,
+	'leading-zero MAJOR.MINOR.PATCH vs v-tag (numeric coercion)'
+);
+
+is(
+	_cmp( '080.088.089', 'V80.88.89' ),
+	0,
+	'leading zeros + mixed V/v on equal cores'
+);
+
+is(
+	_cmp( '1.0.0-rc.01', 'v1.0.0-rc.1' ),
+	0,
+	'prerelease numeric ids: leading zeros compare as integers'
+);
+
+is(
+	_cmp( 'v3.0.0', '2.99.99' ),
+	1,
+	'v-prefixed left side still orders by SemVer core'
+);
+
+is(
+	_cmp( 'V2.7.1-BETA.1', 'v2.7.1-beta.1' ),
+	0,
+	'case fold: full version string lowercased before compare (with vers_tag-style v)'
+);
+
+is(
+	_cmp( '01.0.0', '1.0.0-alpha' ),
+	1,
+	'zero-padded stable core still ranks above prerelease of same logical release'
+);
+

--- a/libs/phplib/loxberry_system.php
+++ b/libs/phplib/loxberry_system.php
@@ -114,7 +114,7 @@
 // 
 class LBSystem
 {
-	public static $LBSYSTEMVERSION = "2.2.1.1";
+	public static $LBSYSTEMVERSION = "2.2.1.2";
 	public static $lang=NULL;
 	private static $SL=NULL;
 		
@@ -420,6 +420,117 @@ class LBSystem
 		}
 		
 		return isset($plugin['PLUGINDB_VERSION']) ? $plugin['PLUGINDB_VERSION'] : null;
+	}
+
+	##################################################################################
+	# SemVer-style plugin version compare (parity with Perl LoxBerry::System::plugin_version_compare).
+	# PHP legacy fallback uses version_compare(); edge cases may differ from Perl version.pm lax mode.
+	##################################################################################
+	public static function plugin_version_compare($a_in = null, $b_in = null)
+	{
+		if ($a_in === null && $b_in === null) return 0;
+		if ($a_in === null || $b_in === null) return null;
+		$tag_a = LBSystem::_plugin_normalize_version_tag($a_in);
+		$tag_b = LBSystem::_plugin_normalize_version_tag($b_in);
+		$pa = LBSystem::_plugin_semver_parts($tag_a);
+		$pb = LBSystem::_plugin_semver_parts($tag_b);
+
+		if ($pa['ok'] && $pb['ok']) {
+			if ($pa['maj'] != $pb['maj']) return $pa['maj'] < $pb['maj'] ? -1 : 1;
+			if ($pa['min'] != $pb['min']) return $pa['min'] < $pb['min'] ? -1 : 1;
+			if ($pa['pat'] != $pb['pat']) return $pa['pat'] < $pb['pat'] ? -1 : 1;
+
+			$ea = ($pa['pre'] === '');
+			$eb = ($pb['pre'] === '');
+			if (!$ea && $eb) return -1;
+			if ($ea && !$eb) return 1;
+			if ($ea && $eb) return 0;
+
+			return LBSystem::_plugin_semver_prerelease_cmp($pa['pre'], $pb['pre']);
+		}
+
+		$oa = LBSystem::_plugin_normalize_version_tag($tag_a, true);
+		$ob = LBSystem::_plugin_normalize_version_tag($tag_b, true);
+		if ($oa === '' || $ob === '') return null;
+
+		$vv = @version_compare($oa, $ob);
+		if ($vv === null || $vv === false) return null;
+		return $vv < 0 ? -1 : ($vv > 0 ? 1 : 0);
+	}
+
+	public static function plugin_version_has_prerelease($v_in = null)
+	{
+		if ($v_in === null || trim((string)$v_in) === '') return false;
+		$tag = LBSystem::_plugin_normalize_version_tag($v_in);
+		$p = LBSystem::_plugin_semver_parts($tag);
+		return $p['ok'] && $p['pre'] !== '';
+	}
+
+	private static function _plugin_normalize_version_tag($vers, $reverse = false)
+	{
+		$vers = strtolower(trim((string)$vers));
+		if ($vers === '') return '';
+		if (substr($vers, 0, 1) !== 'v' && !$reverse)
+			$vers = 'v' . $vers;
+		if (substr($vers, 0, 1) === 'v' && $reverse)
+			$vers = substr($vers, 1);
+		return $vers;
+	}
+
+	private static function _plugin_semver_parts($tag)
+	{
+		$r = ['ok'=>false,'maj'=>0,'min'=>0,'pat'=>0,'pre'=>''];
+		if ($tag === null || $tag === '')
+			return $r;
+		$s = $tag;
+		if ($s !== '' && $s[0] === 'v')
+			$s = substr($s, 1);
+		$p = strpos($s, '+');
+		if ($p !== false)
+			$s = substr($s, 0, $p);
+		if (preg_match('/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/', $s, $m)) {
+			$r['ok'] = true;
+			$r['maj'] = (int)$m[1];
+			$r['min'] = (int)$m[2];
+			$r['pat'] = (int)$m[3];
+			$r['pre'] = isset($m[4]) ? $m[4] : '';
+			return $r;
+		}
+		return $r;
+	}
+
+	private static function _plugin_semver_prerelease_cmp($a, $b)
+	{
+		$pa = explode('.', $a);
+		$pb = explode('.', $b);
+		$i = 0;
+		while (true) {
+			$ida = isset($pa[$i]) ? $pa[$i] : null;
+			$idb = isset($pb[$i]) ? $pb[$i] : null;
+
+			if ($ida === null && $idb === null) return 0;
+			if ($ida === null) return -1;
+			if ($idb === null) return 1;
+
+			$na = ctype_digit((string)$ida);
+			$nb = ctype_digit((string)$idb);
+			if ($na && $nb) {
+				$ixa = intval($ida, 10);
+				$ixb = intval($idb, 10);
+				if ($ixa !== $ixb)
+					return $ixa < $ixb ? -1 : 1;
+			}
+			elseif ($na && !$nb)
+				return -1;
+			elseif (!$na && $nb)
+				return 1;
+			else {
+				$wc = strcmp($ida, $idb);
+				if ($wc !== 0)
+					return $wc < 0 ? -1 : 1;
+			}
+			$i++;
+		}
 	}
 
 	##################################################################################

--- a/sbin/pluginsupdate.pl
+++ b/sbin/pluginsupdate.pl
@@ -26,7 +26,6 @@ use LoxBerry::System::PluginDB;
 
 use strict;
 use warnings;
-use version;
 
 
 ##########################################################################
@@ -34,7 +33,7 @@ use version;
 ##########################################################################
 
 # Version of this script
-my $scriptversion="3.0.0.1";
+my $scriptversion="3.0.0.3";
 
 # Global vars
 my $update_path = '/tmp/pluginsupdate';
@@ -43,16 +42,9 @@ my $bins = LoxBerry::System::get_binaries();
 my @plugins = LoxBerry::System::get_plugins();
 my $endpointrelease;
 my $endpointprerelease;
-my $prereleasefile = "/tmp/pluginsupdate/prerelease.cfg";
 my $prereleasecfg;
-my $prereleasearchive;
-my $prereleaseinfo;
-my $prereleasever;
 my $releasefile = "/tmp/pluginsupdate/release.cfg";
 my $releasecfg;
-my $releasever;
-my $releasearchive;
-my $releaseinfo;
 my $resp;
 my $installarchive;
 my $installversion;
@@ -109,7 +101,7 @@ foreach my $arg(@ARGV) {
 foreach (@plugins) {
 
 	my $notify;
-	my $currentver;
+	my $currentver_raw;
 	my $release;
 	my $prerelease;
 	my $pid;
@@ -118,27 +110,29 @@ foreach (@plugins) {
 	my $pluginmd5;
 	my $logfile;
 	my $tempfile;
+	my $installtype;
+	my ($rel_verstr, $rel_archive, $rel_info, $rel_ok);
+	my ($pre_verstr, $pre_archive, $pre_info, $pre_ok);
 
 
 	$pid = $_->{PLUGINDB_MD5_CHECKSUM};
-	$currentver = $_->{PLUGINDB_VERSION};
+	$currentver_raw = $_->{PLUGINDB_VERSION};
 	$plugintitle = $_->{PLUGINDB_TITLE};
 	$pluginname = $_->{PLUGINDB_NAME};
 	$pluginmd5 = $_->{PLUGINDB_MD5_CHECKSUM};
 	$installarchive = "";
+	undef $installversion;
 
 	LOGINF "$pluginname: Found plugin $_->{PLUGINDB_TITLE}.";
 
 	#
-	# Checks
+	# Checks — SemVer + legacy lax compare via LoxBerry::System::plugin_version_compare
 	#
-	if ( !version::is_lax(vers_tag($currentver)) ) {
-		LOGCRIT "$pluginname: Cannot check plugin's version number. Is this a real version number? $currentver. Skipping...";
+	if ( !defined LoxBerry::System::plugin_version_compare($currentver_raw, $currentver_raw) ) {
+		LOGCRIT "$pluginname: Cannot check plugin's version number. Is this a real version number? $currentver_raw. Skipping...";
 		next;
-	} else {
-		$currentver = version->parse(vers_tag($currentver));
-		LOGINF "$pluginname: Current version is: $currentver";
 	}
+	LOGINF "$pluginname: Current version is: $currentver_raw";
 	
 	if (!$_->{PLUGINDB_AUTOUPDATE}) {
 		LOGINF "$pluginname: Provide no automatic updates. Skipping.";
@@ -189,162 +183,208 @@ foreach (@plugins) {
 	}
 
 	#
-	# Check for a release
+	# Fetch release.cfg (AUTOUPDATE.VERSION)
 	#
-	
-	my $installtype;
-	
+	$rel_ok = 0;
+	$rel_verstr = $rel_archive = $rel_info = undef;
+
 	if ( ($release || $notify) && $endpointrelease ) {
 
 		LOGINF "$pluginname: Requesting release file from $endpointrelease";
 		$resp = `$bins->{CURL} -q --connect-timeout 10 --max-time 60 --retry 5 --raw -LfksSo $releasefile $endpointrelease  2>&1`;
 		if ($? ne 0) {
-			LOGCRIT "$pluginname: Could not fetch RELEASE file. Error: $resp Skipping this plugin...";
-			next;
-		} else {
+			LOGCRIT "$pluginname: Could not fetch RELEASE file. Error: $resp Continuing with prerelease/other channels if any.";
+		}
+		else {
 			LOGOK "$pluginname: Release file fetched.";
 			eval {
 				$releasecfg = new Config::Simple("$releasefile");
 			};
 			if ($@) {
 				LOGCRIT "$pluginname: Fetched release.cfg is not a valid release file. Please report to the plugin author.";
-				next;
 			}
-			$releasever = $releasecfg->param("AUTOUPDATE.VERSION");
-			$releasearchive = $releasecfg->param("AUTOUPDATE.ARCHIVEURL");
-			$releaseinfo = $releasecfg->param("AUTOUPDATE.INFOURL");
+			else {
+				$rel_verstr = $releasecfg->param("AUTOUPDATE.VERSION");
+				$rel_archive = $releasecfg->param("AUTOUPDATE.ARCHIVEURL");
+				$rel_info = $releasecfg->param("AUTOUPDATE.INFOURL");
 
-			if ( version::is_lax(vers_tag($releasever)) ) {
-				$releasever = version->parse(vers_tag($releasever));
-				LOGINF "$pluginname: Found release version: $releasever";
-			} else {
-				LOGCRIT "$pluginname: Cannot check release version number. Is this a real version number?";
-			}
-
-			if ( $releasever > $currentver ) {
-				LOGINF "$pluginname: Release version is newer than current installed version.";
-				$installversion = $releasever;
-				$installtype = "release";
-				if ( !$notify ) {
-					$installarchive = $releasearchive;
-				} else {
-					my @notifications = get_notifications( 'plugininstall', "lastnotified-rel-$pluginname");
-					my $last_notified_version;
-					$last_notified_version = $notifications[0]->{version} if ($notifications[0]);
-					delete_notifications('plugininstall', "lastnotified-rel-$pluginname");
-					my %notification = (
-								PACKAGE => "plugininstall",
-								NAME => "lastnotified-rel-$pluginname",
-								MESSAGE => "This helper notification keeps track of last notified release of $plugintitle",
-								SEVERITY => 7,
-								pluginname => $pluginname,
-								pluginmd5 => $pluginmd5,
-								version => "$releasever",
-								installarchive => "$releasearchive",
-								releaseinfo => $releaseinfo,
-								type => "release",
-								LINK => $releaseinfo
-					);
-					LoxBerry::Log::notify_ext( \%notification );
-					if ($last_notified_version && $last_notified_version eq "$releasever") {
-						LOGOK "$pluginname: Skipping notification because version has already been notified.";
-					} elsif ($checkonly) {
-						LOGINF "$pluginname: Skipping notification because of --checkonly parameter. This is an interactive call.";
-					} elsif ($_->{PLUGINDB_AUTOUPDATE} eq "1") {
-						LOGINF "$pluginname: Skipping notification because automatic updates and notifys are disabled.";
-					} else {
-						$message = "$plugintitle - $SL{'PLUGININSTALL.UI_NOTIFY_AUTOINSTALL_RELEASE_AVAILABLE'} $installversion\n";
-						$message .= $SL{'PLUGININSTALL.UI_NOTIFY_AUTOINSTALL_INSTRUCTION'};
-						notify ( "plugininstall", "$pluginname", $message);
-						LOGINF "$pluginname: Notification saved.";
-					}
+				if ( defined(LoxBerry::System::plugin_version_compare($rel_verstr, $rel_verstr)) ) {
+					$rel_ok = 1;
+					LOGINF "$pluginname: Found release version: $rel_verstr";
 				}
-
-			} else {
-				# Installed version is equal or newer. Helper notification can be deleted.
-				LOGINF "$pluginname: Release version is not newer than installed version.";
-				delete_notifications('plugininstall', "lastnotified-rel-$pluginname");
+				else {
+					LOGCRIT "$pluginname: Cannot check release version number. Is this a real version number?";
+					undef $rel_verstr;
+					undef $rel_archive;
+					undef $rel_info;
+				}
 			}
-
 		}
 	}
-	
+
+	if ( !$rel_ok && ($release || $notify) ) {
+		if ( $endpointrelease ) {
+			delete_notifications('plugininstall', "lastnotified-rel-$pluginname");
+			LOGINF "$pluginname: No valid release VERSION to compare.";
+		}
+	}
+	elsif ( $rel_ok && defined(LoxBerry::System::plugin_version_compare($rel_verstr, $currentver_raw))
+		&& LoxBerry::System::plugin_version_compare($rel_verstr, $currentver_raw) != 1 ) {
+		LOGINF "$pluginname: Release version is not newer than installed version.";
+		delete_notifications('plugininstall', "lastnotified-rel-$pluginname");
+	}
+
 	#
-	# Check for a prerelease
+	# Fetch prerelease.cfg
 	#
+	$pre_ok = 0;
+	$pre_verstr = $pre_archive = $pre_info = undef;
+
 	if ( ($prerelease || $notify) && $endpointprerelease ) {
 
 		LOGINF "$pluginname: Requesting prerelease from $endpointprerelease";
 
 		$resp = `$bins->{CURL} -q --connect-timeout 10 --max-time 60 --retry 5 --raw -LfksSo $releasefile $endpointprerelease  2>&1`;
 		if ($? ne 0) {
-			LOGCRIT "$pluginname: Could not fetch PRERELEASE file. Error: $resp Skipping this plugin...";
-			next;
-		} else {
+			LOGCRIT "$pluginname: Could not fetch PRERELEASE file. Error: $resp Continuing with release/other logic if applicable.";
+		}
+		else {
 			LOGOK "$pluginname: Prerelease file fetched.";
 			eval {
 				$prereleasecfg = new Config::Simple("$releasefile");
 			};
 			if ($@) {
 				LOGCRIT "$pluginname: Fetched prerelease.cfg is not a valid release file. Please report to the plugin author.";
-				next;
 			}
-			$prereleasever = $prereleasecfg->param("AUTOUPDATE.VERSION");
-			$prereleasearchive = $prereleasecfg->param("AUTOUPDATE.ARCHIVEURL");
-			$prereleaseinfo = $prereleasecfg->param("AUTOUPDATE.INFOURL");
+			else {
+				$pre_verstr = $prereleasecfg->param("AUTOUPDATE.VERSION");
+				$pre_archive = $prereleasecfg->param("AUTOUPDATE.ARCHIVEURL");
+				$pre_info = $prereleasecfg->param("AUTOUPDATE.INFOURL");
 
-			if ( version::is_lax(vers_tag($prereleasever)) ) {
-				$prereleasever = version->parse(vers_tag($prereleasever));
-				LOGINF "$pluginname: Found prerelease version: $prereleasever";
-			} else {
-				LOGCRIT "$pluginname: Cannot check prerelease version number. Is this a real version number?";
-			}
-
-			if ( $prereleasever > $releasever && $prereleasever > $currentver) {
-				LOGINF "$pluginname: Prerelease version is newer than release version, and newer than installed version.";
-				$installversion = $prereleasever;
-				$installtype = "prerelease";
-				if ( !$notify ) {
-					$installarchive = $prereleasearchive;
-				} else {
-					my @notifications = get_notifications( 'plugininstall', "lastnotified-prerel-$pluginname");
-					my $last_notified_version;
-					$last_notified_version = $notifications[0]->{version} if ($notifications[0]);
-					delete_notifications('plugininstall', "lastnotified-prerel-$pluginname");
-					my %notification = (
-								PACKAGE => "plugininstall",
-								NAME => "lastnotified-prerel-$pluginname",
-								MESSAGE => "This helper notification keeps track of last notified pre-release of $plugintitle",
-								SEVERITY => 7,
-								pluginname => $pluginname,
-								pluginmd5 => $pluginmd5,
-								version => "$prereleasever",
-								installarchive => "$prereleasearchive",
-								releaseinfo => $prereleaseinfo,
-								type => "prerelease",
-								LINK => $prereleaseinfo
-						);
-					LoxBerry::Log::notify_ext( \%notification );
-					if ($last_notified_version && $last_notified_version eq "$prereleasever") {
-						LOGOK "$pluginname: Skipping notification because version has already been notified.";
-					} elsif ($checkonly) {
-						LOGINF "$pluginname: Skipping notification because of --checkonly parameter. This is an interactive call.";
-					} elsif ($_->{PLUGINDB_AUTOUPDATE} eq "1") {
-						LOGINF "$pluginname: Skipping notification because automatic updates and notifys are disabled.";
-					} else {
-						$message = "$plugintitle - $SL{'PLUGININSTALL.UI_NOTIFY_AUTOINSTALL_PRERELEASE_AVAILABLE'} $installversion\n";
-						$message .= $SL{'PLUGININSTALL.UI_NOTIFY_AUTOINSTALL_INSTRUCTION'};
-						notify ( "plugininstall", "$pluginname", $message);
-						LOGINF "$pluginname: Notification saved.";
-					}
+				if ( defined(LoxBerry::System::plugin_version_compare($pre_verstr, $pre_verstr)) ) {
+					$pre_ok = 1;
+					LOGINF "$pluginname: Found prerelease version: $pre_verstr";
 				}
-			} else {
-				LOGINF "$pluginname: Prerelease version is not newer than release version.";
-				delete_notifications('plugininstall', "lastnotified-prerel-$pluginname");
+				else {
+					LOGCRIT "$pluginname: Cannot check prerelease version number. Is this a real version number?";
+					undef $pre_verstr;
+					undef $pre_archive;
+					undef $pre_info;
+				}
 			}
+		}
+	}
 
+	if ( !$pre_ok && ($prerelease || $notify) ) {
+		if ( $endpointprerelease ) {
+			LOGINF "$pluginname: No valid prerelease VERSION to compare.";
+			delete_notifications('plugininstall', "lastnotified-prerel-$pluginname");
+		}
+	}
+	elsif ( $pre_ok && defined(LoxBerry::System::plugin_version_compare($pre_verstr, $currentver_raw))
+		&& LoxBerry::System::plugin_version_compare($pre_verstr, $currentver_raw) != 1 ) {
+		LOGINF "$pluginname: Prerelease channel is not newer than installed version.";
+		delete_notifications('plugininstall', "lastnotified-prerel-$pluginname");
+	}
+
+	#
+	# One chosen update: SemVer + sticky prerelease (stay on beta when both stable and prerelease beat current)
+	#
+	my $cmp_rel =
+		$rel_ok ? LoxBerry::System::plugin_version_compare($rel_verstr, $currentver_raw) : undef;
+	my $cmp_pre =
+		$pre_ok ? LoxBerry::System::plugin_version_compare($pre_verstr, $currentver_raw) : undef;
+	my $rel_gt = (defined($cmp_rel) && $cmp_rel == 1);
+	my $pre_gt = (defined($cmp_pre) && $cmp_pre == 1);
+
+	my $pick_type = undef;
+	if ( $rel_gt || $pre_gt ) {
+		if ( $rel_gt && $pre_gt && LoxBerry::System::plugin_version_has_prerelease($currentver_raw) ) {
+			LOGINF "$pluginname: Stable and prerelease both newer - installed is prerelease; staying on prerelease channel (sticky prerelease).";
+			$pick_type = 'prerelease';
+		}
+		elsif ( $rel_gt && $pre_gt ) {
+			LOGINF "$pluginname: Stable and prerelease both newer - preferring release.";
+			$pick_type = 'release';
+		}
+		elsif ( $rel_gt ) {
+			LOGINF "$pluginname: Preferring newer release.";
+			$pick_type = 'release';
+		}
+		else {
+			LOGINF "$pluginname: Preferring newer prerelease.";
+			$pick_type = 'prerelease';
 		}
 
+		my $picked_ver =
+			$pick_type eq 'release'
+			? $rel_verstr
+			: $pre_verstr;
+		my $picked_arch =
+			$pick_type eq 'release'
+			? $rel_archive
+			: $pre_archive;
+		my $picked_info =
+			$pick_type eq 'release'
+			? $rel_info
+			: $pre_info;
+
+		$installversion = $picked_ver;
+		$installtype = $pick_type;
+
+		if ( !$notify ) {
+			$installarchive = $picked_arch;
+		}
+
+		delete_notifications('plugininstall', "lastnotified-rel-$pluginname") if ( $pick_type eq 'prerelease' );
+		delete_notifications('plugininstall', "lastnotified-prerel-$pluginname") if ( $pick_type eq 'release' );
+
+		my $nh = $pick_type eq 'release' ? "lastnotified-rel-$pluginname" : "lastnotified-prerel-$pluginname";
+		if ( $notify ) {
+			my @notifications = get_notifications( 'plugininstall', $nh );
+			my $last_notified_version = $notifications[0]->{version} if ($notifications[0]);
+			delete_notifications('plugininstall', $nh );
+			my %notification = (
+				PACKAGE => "plugininstall",
+				NAME => $nh,
+				MESSAGE => $pick_type eq 'release'
+					? "This helper notification keeps track of last notified release of $plugintitle"
+					: "This helper notification keeps track of last notified pre-release of $plugintitle",
+				SEVERITY => 7,
+				pluginname => $pluginname,
+				pluginmd5 => $pluginmd5,
+				version => "$picked_ver",
+				installarchive => "$picked_arch",
+				releaseinfo => $picked_info,
+				type => $pick_type,
+				LINK => $picked_info,
+			);
+			LoxBerry::Log::notify_ext( \%notification );
+
+			if ( $last_notified_version && $last_notified_version eq "$picked_ver" ) {
+				LOGOK "$pluginname: Skipping notification because version has already been notified.";
+			}
+			elsif ($checkonly) {
+				LOGINF "$pluginname: Skipping notification because of --checkonly parameter. This is an interactive call.";
+			}
+			elsif ($_->{PLUGINDB_AUTOUPDATE} eq "1") {
+				LOGINF "$pluginname: Skipping notification because automatic updates and notifys are disabled.";
+			}
+			else {
+				if ($pick_type eq 'release') {
+					$message =
+						"$plugintitle - $SL{'PLUGININSTALL.UI_NOTIFY_AUTOINSTALL_RELEASE_AVAILABLE'} $installversion\n";
+					$message .= $SL{'PLUGININSTALL.UI_NOTIFY_AUTOINSTALL_INSTRUCTION'};
+				}
+				else {
+					$message =
+						"$plugintitle - $SL{'PLUGININSTALL.UI_NOTIFY_AUTOINSTALL_PRERELEASE_AVAILABLE'} $installversion\n";
+					$message .= $SL{'PLUGININSTALL.UI_NOTIFY_AUTOINSTALL_INSTRUCTION'};
+				}
+				notify( "plugininstall", "$pluginname", $message );
+				LOGINF "$pluginname: Notification saved.";
+			}
+		}
 	}
 
 	#

--- a/templates/system/plugininstall.html
+++ b/templates/system/plugininstall.html
@@ -478,8 +478,63 @@
 	
 
 	
+/**
+ * SemVer 2 precedence (core + prerelease); build stripped. Null if not classical MAJOR.MINOR.PATCH (+ optional prerelease).
+ * Same rules as LoxBerry::System::plugin_version_compare (Perl) / LBSystem::plugin_version_compare (PHP).
+ */
+function _pluginSemverParts(tag) {
+	var s = ('' + tag).trim().toLowerCase();
+	if (!s) return null;
+	if (s.charAt(0) === 'v') s = s.slice(1);
+	var pPlus = s.indexOf('+');
+	if (pPlus >= 0) s = s.slice(0, pPlus);
+	var re = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/;
+	var m = re.exec(s);
+	if (!m) return null;
+	return { maj: parseInt(m[1], 10), min: parseInt(m[2], 10), pat: parseInt(m[3], 10), pre: m[4] != null ? m[4] : '' };
+}
+
+function _comparePrereleaseId(ida, idb) {
+	var na = /^\d+$/.test(ida);
+	var nb = /^\d+$/.test(idb);
+	if (na && nb) {
+		var ia = parseInt(ida, 10), ib = parseInt(idb, 10);
+		if (ia !== ib) return ia < ib ? -1 : 1;
+		return 0;
+	}
+	if (na && !nb) return -1;
+	if (!na && nb) return 1;
+	if (ida < idb) return -1;
+	if (ida > idb) return 1;
+	return 0;
+}
+
+function _semverCompareRaw(a, b) {
+	var pa = _pluginSemverParts(a), pb = _pluginSemverParts(b);
+	if (!pa || !pb) return null;
+	if (pa.maj !== pb.maj) return pa.maj < pb.maj ? -1 : 1;
+	if (pa.min !== pb.min) return pa.min < pb.min ? -1 : 1;
+	if (pa.pat !== pb.pat) return pa.pat < pb.pat ? -1 : 1;
+	var ea = pa.pre === '', eb = pb.pre === '';
+	if (!ea && eb) return -1;
+	if (ea && !eb) return 1;
+	if (ea && eb) return 0;
+	var iparts = pa.pre.split('.'), jparts = pb.pre.split('.');
+	for (var ii = 0; ; ii++) {
+		var hasA = ii < iparts.length, hasB = ii < jparts.length;
+		if (!hasA && !hasB) return 0;
+		if (!hasA) return -1;
+		if (!hasB) return 1;
+		var cmp = _comparePrereleaseId(iparts[ii], jparts[ii]);
+		if (cmp !== 0) return cmp;
+	}
+}
+
 // 	https://stackoverflow.com/questions/6832596/how-to-compare-software-version-number-using-js-only-number
 function versionCompare(v1, v2, options) {
+	var sc = _semverCompareRaw(v1, v2);
+	if (sc !== null) return sc;
+
     var lexicographical = options && options.lexicographical,
         zeroExtend = options && options.zeroExtend,
         v1parts = v1.split('.'),


### PR DESCRIPTION
- Add plugin_version_compare and plugin_version_has_prerelease to LoxBerry::System (SemVer 2 precedence, stable vs prerelease of the same X.Y.Z per spec, build metadata stripped; lax version.pm fallback when strings are not classic SemVer). Bump Perl module version.
- Mirror the same helpers on LBSystem in loxberry_system.php for PHP consumers; bump PHP system library version.
- Rework pluginsupdate.pl to compare release/prerelease/current via the SDK; pick a single update with sticky-prerelease when both channels beat installed and the running version is already a prerelease, otherwise prefer release when both are newer; continue when curl fails on one channel instead of skipping the whole plugin; bump script version.
- Extend plugininstall.html versionCompare with a SemVer-first path aligned to Perl/PHP, keeping the legacy dotted-number branch for odd version strings.
- Add libs/perllib/t/plugin_semver.t (Test::More) for compare ordering, prerelease vs stable edge cases, and pick-policy mirrors.

Refs: #1504

<img width="959" height="721" alt="image" src="https://github.com/user-attachments/assets/135894a3-c67f-4a84-b346-2135e0f87801" />
