### PR TITLE
fix: color tab-bar img icons in active state

### DIFF
--- a/templates/system/pagestart.html
+++ b/templates/system/pagestart.html
@@ -146,7 +146,7 @@
 			<span><TMPL_VAR HEADER.PANEL_HOME></span>
 		</a>
 		<button class="lb-tab-bar-item" onclick="toggleTabPopup('plugins')" data-role="none">
-			<img src="/system/images/icons/main_plugins_title.svg" width="22" height="22" style="filter: brightness(0) invert(1) opacity(0.7);" alt="">
+			<img src="/system/images/icons/main_plugins_title.svg" class="lb-tab-bar-icon" alt="">
 			<span><TMPL_VAR HEADER.PANEL_MYPLUGINS></span>
 		</button>
 		<a href="/admin/system/updates.cgi" class="lb-tab-bar-item" data-tab-path="/admin/system/updates.cgi">
@@ -154,7 +154,7 @@
 			<span><TMPL_VAR HEADER.PANEL_UPDATES></span>
 		</a>
 		<button class="lb-tab-bar-item" onclick="toggleTabPopup('settings')" data-role="none">
-			<img src="/system/images/icons/main_system_title.svg" width="22" height="22" style="filter: brightness(0) invert(1) opacity(0.7);" alt="">
+			<img src="/system/images/icons/main_system_title.svg" class="lb-tab-bar-icon" alt="">
 			<span><TMPL_VAR HEADER.PANEL_SYSTEMSETTINGS></span>
 		</button>
 		<button class="lb-tab-bar-item" onclick="toggleTabPopup('more')" aria-label="<TMPL_VAR HEADER.PANEL_MORE>" data-role="none">

--- a/webfrontend/html/system/css/components.css
+++ b/webfrontend/html/system/css/components.css
@@ -1118,9 +1118,23 @@ button.lb-tab-bar-item {
 	color: var(--lb-tab-bar-text);
 }
 
+/* SVG icons rendered as <img>. Inactive: tinted to match --lb-tab-bar-text
+   via brightness/invert. Active: hue-rotated filter chain approximates
+   --lb-tab-bar-active (#6dac20). */
+.lb-tab-bar-item img.lb-tab-bar-icon {
+	width: 22px;
+	height: 22px;
+	filter: brightness(0) invert(1) opacity(0.7);
+}
+
 .lb-tab-bar-item.active i,
 .lb-tab-bar-item.active span {
 	color: var(--lb-tab-bar-active);
+}
+
+.lb-tab-bar-item.active img.lb-tab-bar-icon {
+	filter: brightness(0) saturate(100%) invert(55%) sepia(60%) saturate(500%) hue-rotate(51deg) brightness(100%);
+	opacity: 1;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- "Meine Plugins" and "System-Einstellungen" use `<img>` SVGs in the mobile tab-bar (`templates/system/pagestart.html`) while all other items use PrimeIcons. The `<img>` tags carried an inline `style="filter: brightness(0) invert(1) opacity(0.7);"`. Combined with a missing `.lb-tab-bar-item.active img` rule, the icon stayed grey when activated while the label turned green correctly.
- Move the inactive filter into a new `.lb-tab-bar-icon` class in `webfrontend/html/system/css/components.css` and add an active-state rule that hue-rotates to `--lb-tab-bar-active` (`#6dac20`).

## Files
- `templates/system/pagestart.html` — drop inline `style`/`width`/`height`, add `class="lb-tab-bar-icon"` on the two img tags.
- `webfrontend/html/system/css/components.css` — add `.lb-tab-bar-item img.lb-tab-bar-icon` (inactive) and `.lb-tab-bar-item.active img.lb-tab-bar-icon` (active) inside the Tab Bar section.

## Bug
Reported against LoxBerry 4.0.0.2. Reproduction:
1. Open any Core page (e.g. `/admin/system/updates.cgi`) on a mobile width.
2. Click "Meine Plugins" or "System-Einstellungen".
3. Expected: icon turns green like the Updates icon. Actual (before fix): label turns green, icon stays grey.

## Test plan
- [ ] Load a Core page on a mobile viewport and confirm "Meine Plugins" / "System-Einstellungen" icons turn green when their popup is open.
- [ ] Confirm "Home" / "Updates" / "More" icons (PrimeIcons) still turn green when active — the existing `.active i` rule is untouched.
- [ ] Verify all themes (classic-lb, clean-admin, glass, soft-rounded, modern, dark) — they all share `--lb-sidebar-active-text: #6dac20`, so the hue-rotated filter matches.