### PR TITLE
fix: scale section-title icons on plugins/system index pages

### DIFF
--- a/templates/system/index.html
+++ b/templates/system/index.html
@@ -19,7 +19,7 @@
 
 <TMPL_IF PAGE_PLUGIN>
 <p class="lb-section-title" style="display:flex;align-items:center;gap:12px;">
-	<img width="64" height="64" src="/system/images/icons/main_plugins_title.svg" alt="">
+	<img width="32" height="32" src="/system/images/icons/main_plugins_title.svg" alt="">
 	<TMPL_VAR HEADER.TITLE_PAGE_PLUGINS>
 </p>
 
@@ -53,7 +53,7 @@
 <TMPL_IF PAGE_SYSTEM>
 
 <p class="lb-section-title" style="display:flex;align-items:center;gap:12px;">
-	<img height="64" width="64" src="/system/images/icons/main_system_title.svg" alt="">
+	<img width="32" height="32" src="/system/images/icons/main_system_title.svg" alt="">
 	<TMPL_VAR HEADER.TITLE_PAGE_SYSTEM>
 </p>
 <!-- START Widget container -->


### PR DESCRIPTION
## Summary
On the Plugins and System index pages (`templates/system/index.html`), the leading title icons are rendered at `64x64` next to a `.lb-section-title` paragraph (`font-size: 1.15rem` ~= 18px). The ~3.5:1 ratio makes the icon visually dominate the heading.

Scaled both icons down to `32x32` — standard ~1.8:1 ratio for "leading icon next to heading" patterns.

## Files
- `templates/system/index.html` lines 22 and 56 — `width="64" height="64"` → `width="32" height="32"`. Also normalised the attribute order on the second tag (was `height` then `width`).

## Test plan
- [ ] Open `/admin/system/index.cgi?form=plugins` and confirm the puzzle icon sits proportionally next to "Plugins".
- [ ] Open `/admin/system/index.cgi?form=system` and confirm the gear icon sits proportionally next to the System heading.
- [ ] Verify across themes (classic-lb, clean-admin, glass, soft-rounded, modern, dark) — purely a markup change, no theme-specific assets touched.

## Note
`plugininstall.html` uses a 72x72 version of the same icon, but in a different flex layout (icon and section-title text are siblings, not nested). That layout looks acceptable as-is and is out of scope for this PR.