### PR TITLE
fix: UI-audit theme-consistency, layout & icon-sizing fixes

### DIFF
--- a/templates/system/admin.html
+++ b/templates/system/admin.html
@@ -156,8 +156,12 @@
 			validate_enable('#securepinold');
 			$("#adminpass1").on('keyup', function(e) { validate_chk_value( "#adminpass2","keyup","special:compare-with:#adminpass1"); });
 			$("#securepin1").on('keyup', function(e) { validate_chk_value( "#securepin2","keyup","special:compare-with:#securepin1"); });
-			$("#adminpassold").css("background-color","#FFFFC0").attr("original-background-color","#FFFFC0");
-			$("#securepinold").css("background-color","#FFFFC0").attr("original-background-color","#FFFFC0");
+			// Theme-aware "must re-enter" highlight; falls back to the classic
+			// yellow if the variable is unset. validate.js restores fields to
+			// their original-background-color, so store the resolved value there.
+			var lbHighlightBg = getComputedStyle(document.body).getPropertyValue('--lb-highlight-bg').trim() || "#FFFFC0";
+			$("#adminpassold").css("background-color",lbHighlightBg).attr("original-background-color",lbHighlightBg);
+			$("#securepinold").css("background-color",lbHighlightBg).attr("original-background-color",lbHighlightBg);
 			validate_chk_object(['#adminuser','#adminpass1','#adminpass2','#securepin1','#securepin2','#securepinold','#adminpassold']);
 		});
 	</SCRIPT>

--- a/templates/system/index.html
+++ b/templates/system/index.html
@@ -19,7 +19,7 @@
 
 <TMPL_IF PAGE_PLUGIN>
 <p class="lb-section-title" style="display:flex;align-items:center;gap:12px;">
-	<img width="64" height="64" src="/system/images/icons/main_plugins_title.svg" alt="">
+	<img width="32" height="32" src="/system/images/icons/main_plugins_title.svg" alt="">
 	<TMPL_VAR HEADER.TITLE_PAGE_PLUGINS>
 </p>
 
@@ -53,7 +53,7 @@
 <TMPL_IF PAGE_SYSTEM>
 
 <p class="lb-section-title" style="display:flex;align-items:center;gap:12px;">
-	<img height="64" width="64" src="/system/images/icons/main_system_title.svg" alt="">
+	<img width="32" height="32" src="/system/images/icons/main_system_title.svg" alt="">
 	<TMPL_VAR HEADER.TITLE_PAGE_SYSTEM>
 </p>
 <!-- START Widget container -->

--- a/templates/system/pagestart.html
+++ b/templates/system/pagestart.html
@@ -146,7 +146,7 @@
 			<span><TMPL_VAR HEADER.PANEL_HOME></span>
 		</a>
 		<button class="lb-tab-bar-item" onclick="toggleTabPopup('plugins')" data-role="none">
-			<img src="/system/images/icons/main_plugins_title.svg" width="22" height="22" style="filter: brightness(0) invert(1) opacity(0.7);" alt="">
+			<span class="lb-tab-icon" style="-webkit-mask-image:url('/system/images/icons/main_plugins_title.svg'); mask-image:url('/system/images/icons/main_plugins_title.svg');" aria-hidden="true"></span>
 			<span><TMPL_VAR HEADER.PANEL_MYPLUGINS></span>
 		</button>
 		<a href="/admin/system/updates.cgi" class="lb-tab-bar-item" data-tab-path="/admin/system/updates.cgi">
@@ -154,7 +154,7 @@
 			<span><TMPL_VAR HEADER.PANEL_UPDATES></span>
 		</a>
 		<button class="lb-tab-bar-item" onclick="toggleTabPopup('settings')" data-role="none">
-			<img src="/system/images/icons/main_system_title.svg" width="22" height="22" style="filter: brightness(0) invert(1) opacity(0.7);" alt="">
+			<span class="lb-tab-icon" style="-webkit-mask-image:url('/system/images/icons/main_system_title.svg'); mask-image:url('/system/images/icons/main_system_title.svg');" aria-hidden="true"></span>
 			<span><TMPL_VAR HEADER.PANEL_SYSTEMSETTINGS></span>
 		</button>
 		<button class="lb-tab-bar-item" onclick="toggleTabPopup('more')" aria-label="<TMPL_VAR HEADER.PANEL_MORE>" data-role="none">

--- a/templates/system/plugininstall.html
+++ b/templates/system/plugininstall.html
@@ -112,7 +112,7 @@
 
 	<div style="display:flex; width:100%; text-align:left; align-items:center;">
 		<div style="padding:5px 10px 5px 0;">
-			<img width="72" height="72" src="/system/images/icons/main_plugins_title.svg" alt="">
+			<img width="32" height="32" src="/system/images/icons/main_plugins_title.svg" alt="">
 		</div>
 		<div style="width:100%; text-align:left;">
 			<div class="lb-section-title"><TMPL_VAR PLUGININSTALL.UI_LABEL_INSTALLED_PLUGINS></div>

--- a/templates/system/plugininstall.html
+++ b/templates/system/plugininstall.html
@@ -67,7 +67,7 @@
 	
 	<div style="display:flex; width:100%; text-align:left; align-items:center;" id="installationheader">
 		<div style="padding:5px 10px 5px 0;">
-			<img width="72" height="72" src="/system/images/icons/main_plugininstall.svg" alt="">
+			<img width="32" height="32" src="/system/images/icons/main_plugininstall.svg" alt="">
 		</div>
 		<div style="width:100%; text-align:left;">
 			<div class="lb-section-title"><TMPL_VAR PLUGININSTALL.UI_LABEL_INSTALLATION></div>

--- a/templates/system/plugininstall.html
+++ b/templates/system/plugininstall.html
@@ -58,8 +58,11 @@
 	/* remove the border-bottom on pluginrow cells — that's the line above Automatic Updates */
 	table.lb-table tbody tr.pluginrow td { border-bottom: none !important; }
 
-	/* title cell: take all available width */
-	table.lb-table tbody tr.pluginrow td.plugin-title-cell { width: 100% !important; max-width: 0; }
+	/* title cell: take all available width. (No max-width:0 here — that was
+	   carried over from an ellipsis idiom and, combined with the cell's
+	   overflow:hidden + white-space:normal, collapsed the cell to ~0px and
+	   wrapped the plugin name character-by-character vertically — audit Bug.) */
+	table.lb-table tbody tr.pluginrow td.plugin-title-cell { width: 100% !important; max-width: none; }
 	</style>
 	
 	<div style="display:flex; width:100%; text-align:left; align-items:center;" id="installationheader">

--- a/webfrontend/html/system/css/components.css
+++ b/webfrontend/html/system/css/components.css
@@ -642,6 +642,10 @@ button.lb-btn-danger:hover {
 	display: flex;
 	flex-direction: column;
 	min-height: 100vh;
+	/* border-box so the tab-bar-mode padding-bottom is included in the 100vh
+	   instead of being added on top of it (which caused a spurious vertical
+	   scrollbar with empty space in nav-mode-tabbar — audit Bug 05). */
+	box-sizing: border-box;
 	overflow-x: hidden;
 	background: var(--lb-bg);
 	transition: margin-left 0.35s cubic-bezier(0.4, 0, 0.2, 1),

--- a/webfrontend/html/system/css/components.css
+++ b/webfrontend/html/system/css/components.css
@@ -854,14 +854,14 @@ a.lb-sidebar-link.active:visited {
 .lb-header-btn {
 	width: 36px !important;
 	height: 36px !important;
-	background: var(--lb-primary) !important;
+	background: var(--lb-header-btn-bg) !important;
 	border-radius: 8px !important;
 	display: flex !important;
 	align-items: center;
 	justify-content: center;
 	font-size: 16px !important;
 	font-weight: normal !important;
-	color: white !important;
+	color: var(--lb-header-btn-text) !important;
 	text-decoration: none !important;
 	text-shadow: none !important;
 	transition: all 0.15s ease;
@@ -1112,6 +1112,21 @@ button.lb-tab-bar-item {
 	color: var(--lb-tab-bar-text);
 }
 
+/* SVG icons rendered as a CSS mask so they inherit the same theme colors and
+   active-state switch as the .pi font icons (instead of a hardcoded white
+   filter that ignored the active state — see audit Bug 01). */
+.lb-tab-bar-item .lb-tab-icon {
+	width: 22px;
+	height: 22px;
+	background-color: var(--lb-tab-bar-text);
+	-webkit-mask-position: center;
+	        mask-position: center;
+	-webkit-mask-repeat: no-repeat;
+	        mask-repeat: no-repeat;
+	-webkit-mask-size: contain;
+	        mask-size: contain;
+}
+
 .lb-tab-bar-item span {
 	font-size: 10px;
 	font-weight: 500;
@@ -1121,6 +1136,10 @@ button.lb-tab-bar-item {
 .lb-tab-bar-item.active i,
 .lb-tab-bar-item.active span {
 	color: var(--lb-tab-bar-active);
+}
+
+.lb-tab-bar-item.active .lb-tab-icon {
+	background-color: var(--lb-tab-bar-active);
 }
 
 @media (max-width: 768px) {

--- a/webfrontend/html/system/css/design-tokens.css
+++ b/webfrontend/html/system/css/design-tokens.css
@@ -53,10 +53,19 @@ html, body {
   --lb-btn-primary-text: white;
   --lb-btn-primary-border: var(--lb-primary-hover);
 
+  /* === Header action buttons === */
+  /* Defaults to the brand green (light themes); dark themes override. */
+  --lb-header-btn-bg: var(--lb-primary);
+  --lb-header-btn-text: #fff;
+
   /* === Inputs === */
   --lb-input-bg: #fff;
   --lb-input-border: var(--lb-border-color);
   --lb-input-text: var(--lb-text);
+
+  /* Attention highlight for "must re-enter" fields (current password/PIN).
+     Light themes keep the classic yellow; dark themes override below. */
+  --lb-highlight-bg: #FFFFC0;
 
   /* === Toggle === */
   --lb-toggle-bg: #d4d4d4;

--- a/webfrontend/html/system/css/theme-glass.css
+++ b/webfrontend/html/system/css/theme-glass.css
@@ -33,6 +33,13 @@ body.theme-glass {
   --lb-input-border: rgba(255,255,255,.1);
   --lb-input-text: rgba(255,255,255,.8);
 
+  /* Glassy header buttons instead of solid brand green on the dark header */
+  --lb-header-btn-bg: rgba(255,255,255,.1);
+  --lb-header-btn-text: rgba(255,255,255,.85);
+
+  /* Subtle warm tint for the "must re-enter" fields — readable on dark bg */
+  --lb-highlight-bg: rgba(255,235,120,.16);
+
   --lb-toggle-bg: rgba(255,255,255,.15);
 
   --lb-sidebar-bg: rgba(255,255,255,.04);


### PR DESCRIPTION
## Changelog (kurz)

- **Tab-Leiste:** Aktives Element wird wieder in der Akzentfarbe hervorgehoben — die SVG-Icons folgen jetzt dem Theme wie die Font-Icons.
- **Header-Buttons:** Beziehen ihre Farbe aus dem Theme (im Glass-Theme nicht mehr knallgrün auf dunklem Header).
- **Admin – Passwort/SecurePIN-Felder:** Theme-gerechte Hervorhebung statt grellem Gelb auf dunklem Hintergrund.
- **Startseite (Tab-Leisten-Modus):** Kein unnötiger vertikaler Scrollbalken mehr, wenn der Inhalt in den Viewport passt.
- **Plugin-Verwaltung:** Langer Plugin-Name bricht nicht mehr zeichenweise senkrecht um.
- **Icons:** Section-Title-Icons einheitlich verkleinert (Plugins-/System-Startseiten 64→32, „Installation"/„Installierte Plugins" 72→32).

---

## Details

Combines two batches of UI/UX-audit fixes (v4.0.0.2) where hardcoded colors/filters bypassed the active theme, plus two layout bugs and consistent section-title icon sizing. **Supersedes #1510** (section-title icons) and **#1509** (tab-bar icon active state). All verified live (Claude-for-Chrome) on classic + glass themes.

### Bug 01 — Tab-bar SVG icons ignored the active state
"Meine Plugins" / "System-Einstellungen" used a hardcoded `filter: brightness(0) invert(1) opacity(.7)` on the `<img>`, so they never switched to the active accent color (unlike the `.pi` font icons). Now rendered as a CSS `mask-image` span (`.lb-tab-icon`) inheriting `--lb-tab-bar-text` (inactive) / `--lb-tab-bar-active` (active) — exact accent color, theme-aware. (Supersedes #1509, which approximated the green via a `hue-rotate` filter chain.)

### Bug 02 — Header buttons hardcoded to the brand green
`.lb-header-btn` was bound to `var(--lb-primary) !important` with no per-theme override, clashing on the glass theme's dark transparent header. New `--lb-header-btn-bg` / `--lb-header-btn-text` tokens (default to the brand green → light themes unchanged); glass overrides them to a glassy translucent style.

### Bug 04 — "current password / SecurePIN" fields hardcoded `#FFFFC0`
The two fields in `admin.html` had `#FFFFC0` written via JS (stored as `original-background-color`, which `validate.js` restores to), producing a glaring yellow box on dark themes. Now sourced from a new `--lb-highlight-bg` token; glass overrides to a subtle translucent warm tint. The validate.js restore mechanism is preserved.

### Bug 05 — Spurious vertical scrollbar in nav-mode-tabbar
In tab-bar layout, `.lb-main` gets `min-height: 100vh` plus `padding-bottom: calc(80px + safe-area)`. Because `.lb-main` was `box-sizing: content-box` (no global border-box reset exists), the padding was added on top of the 100vh → document ~80px too tall → vertical scrollbar with empty space even when content fits. Set `box-sizing: border-box` on `.lb-main`. No effect in sidebar mode (no padding there).

### Plugin title cell collapsed to 0px
In `plugininstall.html` the title cell had `width: 100% !important; max-width: 0`. The `max-width:0` (carried over from an ellipsis idiom) combined with the cell's `overflow:hidden` + `white-space:normal` collapsed it to ~0px, wrapping the plugin name character-by-character vertically. Changed to `max-width: none`.

### Section-title icon sizing
Leading icons next to `.lb-section-title` (~18px text) were oversized: 64×64 on the Plugins/System index pages and 72×72 in the plugin-management header. Scaled all to 32×32 for a consistent ~1.8:1 icon-to-heading ratio. (Index-page part folded in from #1510.)

## Verification (Claude-for-Chrome, live)
| Item | Classic | Glass |
|---|---|---|
| 01 active / inactive tab icon | `rgb(109,172,32)` / `rgba(255,255,255,.7)` | same logic |
| 02 header button bg | `rgb(109,172,32)` (unchanged) | `rgba(255,255,255,.1)` |
| 04 highlight field bg | `rgb(255,255,192)` | `rgba(255,235,120,.16)` |
| 05 tab-bar-mode overflow | `0px` (was ~80px); sidebar mode `0px` (no regression) | — |
| plugin title / icons | renders horizontally; icons 32px | — |

## Notes
- Light themes (classic-lb, soft-rounded, clean-admin) are visually unchanged — only the dark glass theme gets the new overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
