### PR TITLE
fix: non-UTF8 bytes in plugindatabase.json break all plugins (#1512)

### DIFF
--- a/libs/perllib/LoxBerry/System.pm
+++ b/libs/perllib/LoxBerry/System.pm
@@ -421,11 +421,25 @@ sub get_plugins
 	print STDERR "get_plugins: Using file $plugindb_file\n" if ($DEBUG);
 	
 	require JSON;
+	require Encode;
 	my $plugindbdata;
+	my $plugindb_raw = LoxBerry::System::read_file( $LoxBerry::System::PLUGINDATABASE );
 	eval {
-		$plugindbdata = JSON::from_json( LoxBerry::System::read_file( $LoxBerry::System::PLUGINDATABASE ) );
+		$plugindbdata = JSON::from_json( $plugindb_raw );
 	};
-	if ($@) {
+	if ($@ || !defined $plugindbdata) {
+		# A single plugin's metadata (e.g. a Latin1-encoded author name from
+		# plugin.cfg) can contain non-UTF8 bytes. Strict JSON backends (e.g.
+		# JSON::XS) reject the WHOLE document on any invalid byte, which would
+		# hide ALL plugins. Recover by substituting the malformed bytes so the
+		# rest of the database still loads. See issue #1512.
+		Carp::carp "LoxBerry::System::get_plugins: $plugindb_file contains invalid UTF-8 - substituting malformed bytes (issue #1512)\n";
+		my $plugindb_clean = Encode::decode( 'UTF-8', $plugindb_raw, Encode::FB_DEFAULT );
+		eval {
+			$plugindbdata = JSON->new->utf8(0)->decode( $plugindb_clean );
+		};
+	}
+	if ($@ || !defined $plugindbdata) {
 		Carp::carp "LoxBerry::System::get_plugins: Could not read $plugindb_file\n";
 		return;
 	}

--- a/libs/phplib/loxberry_system.php
+++ b/libs/phplib/loxberry_system.php
@@ -607,7 +607,17 @@ class LBSystem
 		$plugins = Array();
 		# Read Plugin database copied from plugininstall.pl
 		#$filestr = file(PLUGINDATABASE, FILE_IGNORE_NEW_LINES);
-		$plugindb = json_decode(file_get_contents(PLUGINDATABASE));
+		$plugindb_content = file_get_contents(PLUGINDATABASE);
+		$plugindb = json_decode($plugindb_content);
+		if ($plugindb === null && json_last_error() === JSON_ERROR_UTF8) {
+				// A single plugin's metadata (e.g. a Latin1-encoded author name from
+				// plugin.cfg) can contain non-UTF8 bytes. json_decode() rejects the
+				// WHOLE document on any invalid byte, which would hide metadata, log
+				// assignment and loglevels for ALL plugins. Substitute the malformed
+				// bytes so the rest of the database still loads. See issue #1512.
+				error_log("LoxBerry System WARNING: Plugin Database " . PLUGINDATABASE . " contains invalid UTF-8 - substituting malformed bytes (issue #1512)");
+				$plugindb = json_decode($plugindb_content, false, 512, JSON_INVALID_UTF8_SUBSTITUTE);
+		}
 		if (! $plugindb) {
 				error_log("LoxBerry System ERROR: Could not read Plugin Database " . PLUGINDATABASE);
 				return;

--- a/sbin/plugininstall.pl
+++ b/sbin/plugininstall.pl
@@ -21,7 +21,7 @@
 
 use File::Path qw(make_path remove_tree);
 use Digest::MD5 qw(md5_hex);
-use Encode qw(encode_utf8);
+use Encode qw(encode_utf8 decode);
 use LoxBerry::System;
 use LoxBerry::Update;
 use File::Basename;
@@ -652,14 +652,17 @@ sub install {
 	}
 
 	## Create or update database entry ##
+	# plugin.cfg values may be Latin1-encoded. A single non-UTF8 byte stored
+	# verbatim in plugindatabase.json breaks json_decode() for ALL plugins
+	# (issue #1512), so ensure the free-text fields are valid UTF-8 first.
 	$plugin = LoxBerry::System::PluginDB->plugin(
-        author_name => $pauthorname,
-        author_email => $pauthoremail,
-        plugin_website => $pauthorwebsite,
+        author_name => _ensure_utf8($pauthorname),
+        author_email => _ensure_utf8($pauthoremail),
+        plugin_website => _ensure_utf8($pauthorwebsite),
         name => $pname,
         folder => $pfolder,
         version => $pversion,
-        title => $ptitle,
+        title => _ensure_utf8($ptitle),
         interface => $pinterface,
         autoupdate => $pautoupdates,
         releasecfg => $preleasecfg,
@@ -1693,6 +1696,22 @@ sub is_folder_empty {
 		readdir $dir;	# Skip ..
 		return 0 if( readdir $dir ); # 3rd times a charm
 	return 1;
+}
+
+#####################################################
+# Ensure a string is valid UTF-8 before it is stored in the plugin database.
+# plugin.cfg files are usually UTF-8, but some are Latin1. A stray non-UTF8
+# byte (e.g. Latin1 'á' = 0xE1) written verbatim into plugindatabase.json
+# breaks json_decode() for ALL plugins, not just the offending one (issue #1512).
+# Valid UTF-8 (and ASCII) is kept unchanged; Latin1 is re-encoded to UTF-8.
+#####################################################
+
+sub _ensure_utf8 {
+	my ($str) = @_;
+	return $str if (!defined $str || $str eq '');
+	my $probe = $str;                                 # utf8::decode modifies its argument -> use a copy
+	return $str if utf8::decode($probe);              # already valid UTF-8 -> keep original bytes
+	return encode_utf8( decode('ISO-8859-1', $str) ); # treat as Latin1 -> UTF-8 bytes
 }
 
 #####################################################


### PR DESCRIPTION
Fixes #1512.

## Problem
A single plugin whose metadata contains a non-UTF8 byte (e.g. a Latin1-encoded author name like `Victor Vlasák`, where `á` = `0xE1`) makes `json_decode()` reject the **entire** `plugindatabase.json`. `get_plugins()` then returns nothing for **all** plugins — breaking log-manager plugin assignment, the loglevel selector and every consumer of `plugindata()`.

## Fix — defense in depth
Verified against current `master`; the root-cause analysis in the issue is accurate. Implemented on both write and read side, plus a refinement (the write fix covers **all** free-text fields, not only `author_name`):

**Write — `sbin/plugininstall.pl`**
New `_ensure_utf8()` helper sanitises the free-text `plugin.cfg` fields (`author_name`, `author_email`, `plugin_website`, `title`) before saving. Valid UTF-8 and ASCII stay byte-identical; Latin1 is re-encoded to UTF-8. Prevents bad data from being written in the first place.

**Read PHP — `libs/phplib/loxberry_system.php`**
On `JSON_ERROR_UTF8`, retry `json_decode()` with `JSON_INVALID_UTF8_SUBSTITUTE` so one bad plugin no longer hides all others. (Requires PHP ≥ 7.2 — fine for LoxBerry 4.x.)

**Read Perl — `libs/perllib/LoxBerry/System.pm`**
On parse failure, recover by substituting malformed bytes before decoding. Matters for strict backends like JSON::XS (the bundled JSON::PP is more tolerant).

## Testing
The `_ensure_utf8` logic was unit-tested standalone:
- ASCII / valid UTF-8 → kept byte-identical
- Latin1 `0xE1` → `0xC3 0xA1`
- mixed `Vlas\xE1k` → `566c6173c3a16b`

Full live verification (installing a Latin1 `plugin.cfg`) is best done on a real LoxBerry — handing this over for review.

## Note on already-corrupted installs
The read-path fix makes existing broken `plugindatabase.json` files load again (bad bytes substituted). To properly repair the stored value, the affected plugin can simply be reinstalled (write path now sanitises), or the file can be normalised once:
```bash
sudo php -r '$f="/opt/loxberry/data/system/plugindatabase.json";file_put_contents($f, mb_convert_encoding(file_get_contents($f),"UTF-8","UTF-8"));'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)