### PR TITLE
fix: show real plugin icons in PHP-rendered My-Plugins popup

### DIFF
--- a/libs/phplib/loxberry_web.php
+++ b/libs/phplib/loxberry_web.php
@@ -209,9 +209,12 @@ EOT;
 			$sidebar_html = '<div class="lb-sidebar-section">' . htmlspecialchars($section_label, ENT_QUOTES, 'UTF-8') . '</div>' . "\n";
 			foreach ($installed_plugins as $plugin) {
 				$title = htmlspecialchars($plugin['PLUGINDB_TITLE'], ENT_QUOTES, 'UTF-8');
-				$url   = htmlspecialchars("/admin/plugins/" . $plugin['PLUGINDB_FOLDER'] . "/", ENT_QUOTES, 'UTF-8');
+				$url    = htmlspecialchars("/admin/plugins/" . $plugin['PLUGINDB_FOLDER'] . "/", ENT_QUOTES, 'UTF-8');
+				$folder = htmlspecialchars($plugin['PLUGINDB_FOLDER'], ENT_QUOTES, 'UTF-8');
 				$sidebar_html .= '<a class="lb-sidebar-link" href="' . $url . '"><span class="lb-sidebar-name">' . $title . '</span><div class="lb-sidebar-status"></div></a>' . "\n";
-				$tabbar_html  .= '<a class="lb-tab-popup-item" href="' . $url . '"><i class="pi pi-box"></i><span>' . $title . '</span></a>' . "\n";
+				// Use the plugin's own icon (matches the Perl lbheader); the previous
+				// hardcoded "pi pi-box" showed a generic cube for every plugin.
+				$tabbar_html  .= '<a class="lb-tab-popup-item" href="' . $url . '"><img src="/system/images/icons/' . $folder . '/icon_64.png" width="22" height="22" style="opacity:0.7;" alt=""><span>' . $title . '</span></a>' . "\n";
 			}
 		}
 		$pageobj->param('SIDEBAR_PLUGINS_HTML', $sidebar_html);


### PR DESCRIPTION
## Problem
In the *My Plugins* tab popup, every plugin showed the same generic cube icon instead of its own icon — on PHP-rendered pages (e.g. `services.php`).

## Cause
The PHP `lbheader()` in `loxberry_web.php` built each popup item with a hardcoded `<i class="pi pi-box"></i>` (generic cube). The Perl `lbheader()` (`Web.pm`) already uses each plugin's `icon_64.png` — so the two implementations were out of sync and PHP pages got cubes.

## Fix
Render the plugin's own icon (`/system/images/icons/<folder>/icon_64.png`) in the PHP path too, matching the Perl output.

Verified on a live box: folder names match the icon directories and every plugin has a unique `icon_64.png` (md5-checked, not the `default` cube), so the icons resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)