### PR TITLE
fix(ui): Legacy-jQM-Flipswitch OFF-Zustand wieder neutral statt grün

### DIFF
--- a/templates/system/head.html
+++ b/templates/system/head.html
@@ -16,10 +16,10 @@
 	</TMPL_IF>
 
 	<!-- Design System CSS — always -->
-	<link rel="stylesheet" href="/system/css/design-tokens.css?v=20" />
-	<link rel="stylesheet" href="/system/css/main.css?v=20" />
-	<link rel="stylesheet" href="/system/css/components.css?v=20" />
-	<link rel="stylesheet" href="/system/css/<TMPL_VAR THEME_FILE>?v=20" />
+	<link rel="stylesheet" href="/system/css/design-tokens.css?v=21" />
+	<link rel="stylesheet" href="/system/css/main.css?v=21" />
+	<link rel="stylesheet" href="/system/css/components.css?v=21" />
+	<link rel="stylesheet" href="/system/css/<TMPL_VAR THEME_FILE>?v=21" />
 	<link rel="shortcut icon" href="/system/images/favicon.ico" />
 	<link rel="icon" type="image/png" href="/system/images/favicon-96x96.png" sizes="96x96" />
 	<link rel="icon" type="image/png" href="/system/images/favicon-32x32.png" sizes="32x32" />
@@ -146,7 +146,7 @@
 		});
 	</script>
 	<script src="/system/scripts/browser.js"></script>
-	<script src="/system/scripts/lb-table-sort.js?v=20"></script>
+	<script src="/system/scripts/lb-table-sort.js?v=21"></script>
 	<!-- HTMLHEAD sent by the plugin author: -->
 	<TMPL_VAR HTMLHEAD>
 </head>

--- a/webfrontend/html/system/css/components.css
+++ b/webfrontend/html/system/css/components.css
@@ -132,6 +132,14 @@ fieldset[data-role="controlgroup"]:not(.ui-controlgroup) > select {
 	width: 100%;
 }
 
+/* jQM flipswitch OFF state: the container carries .ui-bar-inherit, which
+   LoxBerry's jQM theme-a paints in brand green — so an OFF switch looked just
+   as green as ON (only the knob position differed). Reset the OFF track to a
+   neutral gray; .ui-flipswitch-active keeps the green ON state untouched. */
+.lb-content .ui-flipswitch:not(.ui-flipswitch-active) {
+	background-color: var(--lb-gray-200) !important;
+}
+
 /* Override jQM page/body styling — scoped to core pages (.lb-layout) only
    so plugin pages keep their default jQM padding/margins. Note: .page_content
    and #page_content are LoxBerry-own wrappers (not jQM) and are intentionally


### PR DESCRIPTION
## Problem

Bei Alt-Plugins, die noch die jQuery-Mobile-UI nutzen (z.B. **Tesla Command**), ist ein **ausgeschalteter Flipswitch grün** — genauso wie ein eingeschalteter. Nur die Knopf-Position unterscheidet sich, der OFF-Zustand ist farblich nicht erkennbar. Gemeldet von einem v4-Nutzer.

## Ursache

Der jQM-Flipswitch-Container trägt die Klasse `.ui-bar-inherit`. Die LoxBerry-jQM-Theme („a") färbt `.ui-bar-inherit` in Markengrün (`#6dac20` = `--lb-primary`). Der OFF-Track erbt dieses Grün — es gab keine Regel, die ihn neutral zurücksetzt. `.ui-flipswitch-active` (ON) setzt zusätzlich dasselbe Grün, daher sind ON und OFF farblich nicht unterscheidbar.

Betrifft **alle vier aktiven Themes** (`soft-rounded` = Default, `clean-admin`, `glass`, `classic-lb`) — keines hatte eine neutrale OFF-Regel.

## Fix

Eine Regel im immer geladenen DS-jQM-Kompat-Layer (`components.css`):

```css
.lb-content .ui-flipswitch:not(.ui-flipswitch-active) {
	background-color: var(--lb-gray-200) !important;
}
```

- Nur der **OFF**-Track wird neutral grau (`--lb-gray-200`); `:not(.ui-flipswitch-active)` lässt den grünen ON-Zustand unberührt.
- Cache-Buster in `head.html` auf `?v=21` gebumpt, damit der Fix ausgeliefert wird.

## Verifikation

- Im Browser mit exakter DS/jQM-CSS-Kette reproduziert und den Fix über **alle vier Themes** geprüft: OFF = `#e5e5e5` (neutral), ON = grün.
- Zusätzlich mit dem **echten Tesla-Command-Markup** (`data-role="flipswitch"` + `custom-label-flipswitch`) gegengeprüft.
- Gegen Release-Tag **4.0.0.13** verifiziert: die bug-relevanten CSS-Dateien (`loxberry.css` + alle 4 Themes) sind byte-identisch, der Bug ist im Release vorhanden.

Reine CSS-/Template-Änderung, keine Auswirkung auf migrierte Core-Seiten oder den ON-Zustand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
