### PR TITLE
fix(JSON): stop write() infinite loop + data loss (split, with test)

### DIFF
--- a/libs/perllib/LoxBerry/JSON.pm
+++ b/libs/perllib/LoxBerry/JSON.pm
@@ -201,10 +201,14 @@ sub write
 	} 
 	else {
 		print STDERR "LoxBerry::JSON->write: No exklusive lock - re-open file\n" if ($DEBUG);
+		# Open read-write ('+<'), NOT '>': '>' truncates the file immediately, before
+		# we hold the lock. If we then fail to get the lock and return, the file is
+		# left empty - a config like general.json can end up at 0 bytes. Truncation
+		# happens after writing instead (truncate below), as the exclusive branch does.
 		# Bail out if open() failed: otherwise $fh is undef and the flock loop below
 		# spins forever on a closed handle (the file exists per the -w check above,
 		# but open can still fail - e.g. a race with tmpfs cleanup, or EMFILE).
-		if( ! CORE::open($fh, '>', $self->{filename}) ) {
+		if( ! CORE::open($fh, '+<', $self->{filename}) ) {
 			print STDERR "LoxBerry::JSON->write: ERROR Could not open $self->{filename}: $!\n";
 			return undef;
 		}
@@ -220,6 +224,7 @@ sub write
 			close($fh);
 			return undef;
 		}
+		seek($fh, 0, 0);
 	}
 	print STDERR "LoxBerry::JSON->write: Writing\n" if ($DEBUG);
 	print $fh $jsoncontent_new;

--- a/libs/perllib/LoxBerry/JSON.pm
+++ b/libs/perllib/LoxBerry/JSON.pm
@@ -201,14 +201,22 @@ sub write
 	} 
 	else {
 		print STDERR "LoxBerry::JSON->write: No exklusive lock - re-open file\n" if ($DEBUG);
-		CORE::open($fh, '>', $self->{filename}) or print STDERR "Error opening file: $!@\n";
+		# Bail out if open() failed: otherwise $fh is undef and the flock loop below
+		# spins forever on a closed handle (the file exists per the -w check above,
+		# but open can still fail - e.g. a race with tmpfs cleanup, or EMFILE).
+		if( ! CORE::open($fh, '>', $self->{filename}) ) {
+			print STDERR "LoxBerry::JSON->write: ERROR Could not open $self->{filename}: $!\n";
+			return undef;
+		}
+		my $locktimeout = defined $self->{locktimeout} ? $self->{locktimeout} : 5;
 		my $locktime = time();
 		my $is_locked=0;
 		do {
 			$is_locked = flock($fh, 2+4); # LOCK_EX+LOCK_NB
-		} while( !$is_locked and ($locktime+$self->{locktimeout})*2 > time() );
+			select(undef, undef, undef, 0.05) if( ! $is_locked );
+		} while( !$is_locked and ($locktime+$locktimeout) > time() );
 		if( !$is_locked ) {
-			print STDERR "LoxBerry::JSON->write: ERROR Could not get exclusive lock after $self->{locktimeout} seconds\n";
+			print STDERR "LoxBerry::JSON->write: ERROR Could not get exclusive lock after $locktimeout seconds\n";
 			close($fh);
 			return undef;
 		}

--- a/libs/perllib/t/json_write.t
+++ b/libs/perllib/t/json_write.t
@@ -1,0 +1,138 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use File::Spec;
+use File::Temp qw(tempdir);
+use Fcntl qw(:flock);
+
+BEGIN {
+	$ENV{LBHOMEDIR} ||= '/tmp/loxberry_pm_test_home';
+}
+
+# LoxBerry/ lives beside t/ under libs/perllib/
+use lib File::Spec->catdir( $FindBin::Bin, '..' );
+use LoxBerry::JSON;
+
+my $dir = tempdir( CLEANUP => 1 );
+
+sub slurp {
+	my $f = shift;
+	open my $fh, '<', $f or return undef;
+	local $/;
+	return <$fh>;
+}
+
+#
+# Round-trip: create, read back, update, shrink (no trailing garbage)
+#
+{
+	my $f = File::Spec->catfile( $dir, 'roundtrip.json' );
+
+	my $j1 = LoxBerry::JSON->new;
+	my $o1 = $j1->open( filename => $f );
+	$o1->{hello} = 'welt';
+	$o1->{zahl}  = 42;
+	ok( $j1->write(), 'write() creates and writes a new file' );
+
+	my $o2 = LoxBerry::JSON->new->open( filename => $f, readonly => 1 );
+	is( $o2->{hello}, 'welt', 'value read back after create' );
+	is( $o2->{zahl},  42,     'second value read back' );
+
+	my $j3 = LoxBerry::JSON->new;
+	my $o3 = $j3->open( filename => $f );
+	$o3->{zahl} = 99;
+	$j3->write();
+	is( LoxBerry::JSON->new->open( filename => $f, readonly => 1 )->{zahl},
+		99, 'existing value updated' );
+
+	# Write strictly less content than before -> must not leave old bytes behind.
+	my $j4 = LoxBerry::JSON->new;
+	my $o4 = $j4->open( filename => $f );
+	delete $o4->{hello};
+	delete $o4->{zahl};
+	$o4->{x} = 1;
+	$j4->write();
+	my $o5 = LoxBerry::JSON->new->open( filename => $f, readonly => 1 );
+	ok( !exists $o5->{hello}, 'shrunk file: stale key gone (truncated correctly)' );
+	is( $o5->{x}, 1, 'shrunk file: new content intact' );
+}
+
+#
+# writeonclose and lockexclusive branches still work
+#
+{
+	my $f = File::Spec->catfile( $dir, 'branches.json' );
+	{
+		my $j = LoxBerry::JSON->new;
+		my $o = $j->open( filename => $f, writeonclose => 1 );
+		$o->{woc} = 'ja';
+	}
+	is( LoxBerry::JSON->new->open( filename => $f, readonly => 1 )->{woc},
+		'ja', 'writeonclose flushes on destroy' );
+
+	{
+		# Scope the exclusive handle so its LOCK_EX is released before we read
+		# the file back below (a blocking readonly open in the same process would
+		# otherwise deadlock against our own still-held exclusive lock).
+		my $j = LoxBerry::JSON->new;
+		my $o = $j->open( filename => $f, lockexclusive => 1 );
+		$o->{lx} = 7;
+		ok( $j->write(), 'lockexclusive branch writes' );
+	}
+	is( LoxBerry::JSON->new->open( filename => $f, readonly => 1 )->{lx},
+		7, 'lockexclusive value read back' );
+}
+
+#
+# Core regression: a competing writer holds the lock.
+# write() must (a) NOT hang, and (b) NOT empty the file.
+# Guarded by alarm() so a reintroduced infinite loop fails the test loudly
+# instead of hanging the suite.
+#
+{
+	my $f = File::Spec->catfile( $dir, 'contended.json' );
+
+	# Seed a known payload through the module itself.
+	my $seed = LoxBerry::JSON->new;
+	my $so   = $seed->open( filename => $f );
+	$so->{keep} = 'MUST SURVIVE';
+	$seed->write();
+	my $before = slurp($f);
+	cmp_ok( length($before), '>', 0, 'seed file has content' );
+
+	# Open first (the non-exclusive open lock is released on return), THEN a
+	# separate handle grabs LOCK_EX, THEN we try to write.
+	my $j = LoxBerry::JSON->new;
+	my $o = $j->open( filename => $f, locktimeout => 1 );
+	$o->{added} = 'x';
+
+	open my $guard, '+<', $f or die "guard open: $!";
+	ok( flock( $guard, LOCK_EX ), 'competing process holds the exclusive lock' );
+
+	my $returned;
+	my $hung = 0;
+	eval {
+		local $SIG{ALRM} = sub { die "TIMEOUT\n" };
+		alarm 15;
+		$returned = $j->write();
+		alarm 0;
+		1;
+	} or do {
+		alarm 0;
+		$hung = 1 if $@ eq "TIMEOUT\n";
+	};
+
+	ok( !$hung, 'write() does not hang when the lock is held (no infinite loop)' );
+	ok( !$returned, 'write() reports failure instead of claiming success' );
+
+	my $after = slurp($f);
+	cmp_ok( length($after), '>', 0, 'file is NOT truncated to 0 bytes on lock failure' );
+	is( $after, $before, 'file content is left completely intact' );
+
+	flock( $guard, LOCK_UN );
+	close $guard;
+}
+
+done_testing();


### PR DESCRIPTION
## Was & warum

`LoxBerry::JSON->write()` konnte im nicht-exklusiven Zweig **endlos bei 100 % CPU laufen** (und dabei das Logfile des Aufrufers fluten, bis die RAM-Disk voll ist) **und die Zieldatei leeren**. Auf einem produktiven LoxBerry 4.0.0.13 hat das eine Log-Datei in Minuten auf mehrere GB wachsen lassen und die zram-Log-Disk zu 100 % gefüllt.

Der Fehlerpfad ist normalerweise unerreichbar, weil `write()` vorher am `-w`-Check aussteigt — deshalb ist das jahrelang nicht aufgefallen. Er wird erreicht, wenn die Datei beim `-w`-Check beschreibbar ist, das anschließende `open`/`flock` aber scheitert: ein transienter `open`-Fehler **oder ein zweiter Prozess, der den Lock hält**.

## Aufgeteilt in drei nachvollziehbare Commits

**1. `fix(JSON): stop write() spinning forever when open or lock fails`**
Drei Defekte im `else`-Zweig ergeben zusammen die Endlosschleife:
- fehlgeschlagenes `CORE::open` wurde nur gemeldet, nicht behandelt → `$fh` bleibt `undef`, `flock` dreht endlos auf geschlossenem Handle
- die Schleifenbedingung `($locktime + $locktimeout) * 2 > time()` kann nie falsch werden (`$locktime` ist eine Epoch, verdoppelt immer > `time()`) — in `sub open` (Zeile 119) steht sie korrekt **ohne** `* 2`
- `locktimeout` hat keinen Default → `undef`
Fix: `return undef` bei `open`-Fehler (mit `$!`), Default `locktimeout = 5`, `* 2` raus, 50 ms Yield statt Busy-Loop.

**2. `fix(JSON): don't truncate the file before the lock is acquired`**
Der Zweig öffnete mit `'>'`, was die Datei **sofort leert — vor** dem Lock. Scheitert der Lock und `write()` kehrt zurück, bleibt die Datei bei **0 Bytes**. Zwei Prozesse, die dieselbe Datei (z. B. `general.json`) schreiben, können ihren Inhalt komplett verlieren. Fix: `'+<'` statt `'>'` und `seek(0)` nach dem Lock — getrimmt wird wie bisher per `truncate` nach dem Schreiben, genau wie es der `lockexclusive`-Zweig schon macht.

**3. `test(JSON): regression test for write() lock handling`**
`libs/perllib/t/json_write.t` (Test::More, im Stil von `t/plugin_semver.t`). Läuft mit:
```
prove libs/perllib/t/json_write.t
```
Prüft die normalen Schreibpfade (anlegen, lesen, ändern, kürzer schreiben, `writeonclose`, `lockexclusive`) und als Kern-Regression den Fall „zweiter Prozess hält den Lock". Der Contention-Test ist mit `alarm()` abgesichert — eine wieder eingebaute Endlosschleife lässt den Test **fehlschlagen statt hängen**.

## Nachweis (auf dem Pi verifiziert)

Derselbe Test gegen beide Versionen:

| | Upstream master | Mit diesem PR |
|---|---|---|
| `prove` Ergebnis | **3 Tests rot** | **15/15 grün** |
| `write()` bei Lock-Konflikt | hängt (alarm greift) | kehrt nach Timeout zurück |
| Datei danach | **0 Bytes** | Inhalt vollständig erhalten |

## Scope

Bewusst minimal: nur der `else`-Zweig von `write()` (≈ 5 Zeilen Logik + Kommentar) plus der Test. Die analoge `undef`-Warnung in `sub open` (Zeile 119) ist **nicht** mit angefasst — sie gehört nicht zu diesem Fehler und würde den Diff unnötig aufweiten. Der PHP-Spiegel `loxberry_json.php` ist nicht betroffen (`file_put_contents(..., LOCK_EX)`, blockierend, kein Retry-Loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
