### PR TITLE
fix(update): stop lock check from always reporting unattended-upgrade

### DIFF
--- a/libs/perllib/LoxBerry/System.pm
+++ b/libs/perllib/LoxBerry/System.pm
@@ -1382,7 +1382,12 @@ sub lock
 		my $rc_apt_archives_lock;
 		($rc_apt) = LoxBerry::System::execute( 'pgrep "apt-get|apt"' );
 		($rc_dpkg) = LoxBerry::System::execute( 'pgrep "dpkg"' );
-		($rc_unattended_upgrade) = LoxBerry::System::execute( 'pgrep -f /usr/bin/unattended-upgrade' );
+		# Bracket the first letter ('[u]') so this pgrep -f pattern does not match
+		# its own invocation: execute() runs the command in a subshell whose argv
+		# contains this string literally, and 'pgrep -f' would otherwise match that
+		# shell - a permanent false positive that blocks every update. '[u]' matches
+		# a real 'u' in a running unattended-upgrade, but not the literal "[u]".
+		($rc_unattended_upgrade) = LoxBerry::System::execute( 'pgrep -f /usr/bin/[u]nattended-upgrade' );
 		($rc_dpkg_lock) = LoxBerry::System::execute( 'fuser /var/lib/dpkg/lock' );
 		($rc_dpkg_frontend_lock) = LoxBerry::System::execute( 'fuser /var/lib/dpkg/lock-frontend' );
 		($rc_apt_archives_lock) = LoxBerry::System::execute( 'fuser /var/cache/apt/archives/lock' );

--- a/libs/perllib/LoxBerry/Update.pm
+++ b/libs/perllib/LoxBerry/Update.pm
@@ -501,7 +501,12 @@ sub test_dpkg_apt
 
 	for ($i=0; $i<600; $i++) {
 		my ($rc_apt) = LoxBerry::System::execute( 'pgrep "apt-get|apt|dpkg"' );
-		my ($rc_unattended_upgrade) = LoxBerry::System::execute( 'pgrep -f /usr/bin/unattended-upgrade' );
+		# Bracket the first letter ('[u]') so this pgrep -f pattern does not match
+		# its own invocation: execute() runs the command in a subshell whose argv
+		# contains this string literally, and 'pgrep -f' would otherwise match that
+		# shell - a permanent false positive. '[u]' matches a real 'u' in a running
+		# unattended-upgrade, but not the literal "[u]".
+		my ($rc_unattended_upgrade) = LoxBerry::System::execute( 'pgrep -f /usr/bin/[u]nattended-upgrade' );
 		my ($rc_dpkg_lock) = LoxBerry::System::execute( 'fuser /var/lib/dpkg/lock' );
 		my ($rc_dpkg_frontend_lock) = LoxBerry::System::execute( 'fuser /var/lib/dpkg/lock-frontend' );
 		my ($rc_apt_archives_lock) = LoxBerry::System::execute( 'fuser /var/cache/apt/archives/lock' );


### PR DESCRIPTION
## Problem

Jeder UI-Update-Versuch bricht ab mit:

> Anscheinend läuft bereits ein anderes Update. Deine Anfrage wurde abgebrochen. **(Lockstate unattended-upgrade)**

— obwohl **kein** Update läuft: apt/dpkg-Locks sind frei, und der einzige `unattended-upgrade`-Prozess ist der Idle-Waiter `unattended-upgrade-shutdown --wait-for-signal`, der nichts installiert.

## Ursache

Die Update-Sperre prüft mit `pgrep -f /usr/bin/unattended-upgrade`, ob gerade ein Sicherheitsupdate läuft (`LoxBerry::System::lock`, `System.pm:1385`, und `Update.pm::test_dpkg_apt`, `Update.pm:504`).

Diese Prüfung läuft über `LoxBerry::System::execute()`, das jeden Befehl in einer **Subshell** ausführt (`System.pm:1779`):

```perl
my $output = qx { ( $command ) 2>$errfile };
```

Die Kommandozeile dieser Subshell enthält den Suchstring `/usr/bin/unattended-upgrade` **wörtlich** — und `pgrep -f` matcht gegen die volle Kommandozeile, also **gegen die eigene aufrufende Shell**. Die Prüfung meldet damit bei **jedem** Aufruf „läuft", unabhängig davon, ob wirklich etwas läuft. Ein permanenter Fehlalarm, der jedes Update blockiert.

## Fix

Den ersten Buchstaben des Musters klammern: `/usr/bin/[u]nattended-upgrade`.

Als Regex matcht `[u]` ein echtes `u` — ein laufendes `unattended-upgrade` wird also weiterhin erkannt. Die Kommandozeile der aufrufenden Shell enthält aber den *literalen* Text `[u]`, den der Regex nicht matcht → kein Selbsttreffer mehr. Das ist das Standard-Idiom gegen `pgrep -f`/`ps | grep`-Selbsttreffer.

## Verifikation (auf einem Pi, echter Codepfad)

| | vorher | mit Fix |
|---|---|---|
| `pgrep`-Check (nichts läuft) | **rc=0 (found), 3/3** | rc=1 (not found) |
| `LoxBerry::System::lock(lockfile=>'lbupdate')` | meldet `'unattended-upgrade'` | **erfolgreich** |
| simuliertes echtes `/usr/bin/unattended-upgrade` | erkannt | **weiterhin erkannt** |

Beide Fundstellen gefixt: `System.pm` (`lock`) und `Update.pm` (`test_dpkg_apt`). Es gibt keine weiteren Vorkommen dieses Musters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
