### PR TITLE
Add LoxBerry::Auth - token authentication at the Miniserver (Perl, PHP, Python)

### DIFF
--- a/libs/perllib/LoxBerry/Auth.pm
+++ b/libs/perllib/LoxBerry/Auth.pm
@@ -1,0 +1,899 @@
+# Please change version number (numbering after underscore) on EVERY change - keep it two-digits as recommended in perlmodstyle
+# Major.Minor represents LoxBerry version (e.g. 0.23 = LoxBerry V0.2.3)
+
+use strict;
+use Digest::SHA;
+use JSON;
+use URI::Escape;
+use LoxBerry::System;
+
+package LoxBerry::Auth;
+
+# Imported AFTER the package statement on purpose - the flock/O_* constants
+# have to land in this namespace, not in main::
+use Fcntl qw( :flock O_RDWR O_CREAT );
+
+use base 'Exporter';
+
+our @EXPORT_OK = qw (
+	auth_method
+	get_token
+	refresh_token
+	kill_token
+	token_info
+	request
+);
+
+our $VERSION = "4.0.0.1";
+our $DEBUG = 0;
+
+# Permission bits of the Miniserver token API
+our $PERM_ADMIN = 0x01;
+our $PERM_WEB   = 0x02;
+our $PERM_APP   = 0x04;
+our $PERM_SYSWS = 0x100;
+
+# App + Sys-WS: ~3 months lifetime, includes the right to reboot
+our $DEFAULT_PERM = 0x104;
+
+# Renew as soon as less than this many seconds are left
+our $REFRESH_THRESHOLD = 7 * 86400;
+
+# HTTP timeout in seconds
+our $TIMEOUT = 10;
+
+# Below this firmware the token endpoints require application layer encryption
+our $MIN_FIRMWARE = "11.2.10.22";
+
+##################################################################
+# Pure helpers - no I/O, no state
+##################################################################
+
+# Normalise the hashAlg field of getkey2. An empty field means SHA1
+# (Miniservers from before the field was introduced).
+sub _norm_alg
+{
+	my ($alg) = @_;
+	$alg = defined $alg ? uc($alg) : '';
+	$alg =~ s/[^A-Z0-9]//g;
+	return 'SHA1'   if ($alg eq '' or $alg eq 'SHA1');
+	return 'SHA256' if ($alg eq 'SHA256');
+	return undef;
+}
+
+sub _hash_hex
+{
+	my ($alg, $data) = @_;
+	return $alg eq 'SHA256' ? Digest::SHA::sha256_hex($data)
+	                        : Digest::SHA::sha1_hex($data);
+}
+
+# The key from getkey2 is hex encoded and has to be used as raw bytes
+sub _hmac_hex
+{
+	my ($alg, $data, $keyhex) = @_;
+	my $key = pack("H*", $keyhex);
+	return $alg eq 'SHA256' ? Digest::SHA::hmac_sha256_hex($data, $key)
+	                        : Digest::SHA::hmac_sha1_hex($data, $key);
+}
+
+# The Miniserver expects the password hash in uppercase
+sub _pw_hash
+{
+	my ($password, $salt, $alg) = @_;
+	return uc( _hash_hex($alg, "$password:$salt") );
+}
+
+sub _auth_hash
+{
+	my ($user, $pwhash, $keyhex, $alg) = @_;
+	return _hmac_hex($alg, "$user:$pwhash", $keyhex);
+}
+
+sub _token_hash
+{
+	my ($token, $keyhex, $alg) = @_;
+	return _hmac_hex($alg, $token, $keyhex);
+}
+
+# jdev/cfg/api returns its value as a STRING using single quotes - that is not
+# valid JSON and must not be fed to a JSON parser.
+sub _parse_api_value
+{
+	my ($value) = @_;
+	return undef if (!defined $value or $value eq '');
+	my %out;
+	while ( $value =~ /'([^']+)'\s*:\s*(?:'([^']*)'|([^,}\s]+))/g ) {
+		$out{$1} = defined $2 ? $2 : $3;
+	}
+	return undef if (! %out);
+	return \%out;
+}
+
+sub _fw_supported
+{
+	my ($fw) = @_;
+	return 0 if (!defined $fw or $fw eq '');
+	my @is  = split(/\./, $fw);
+	my @min = split(/\./, $MIN_FIRMWARE);
+	for my $i (0..3) {
+		my $a = defined $is[$i]  ? int($is[$i])  : 0;
+		my $b = defined $min[$i] ? int($min[$i]) : 0;
+		return 1 if ($a > $b);
+		return 0 if ($a < $b);
+	}
+	return 1;
+}
+
+# tokenRights is a bitmask; perm 0x104 was measured to return 1924
+sub _rights_granted
+{
+	my ($rights, $bit) = @_;
+	return 0 if (!defined $rights or !defined $bit);
+	return ( (int($rights) & int($bit)) == int($bit) ) ? 1 : 0;
+}
+
+##################################################################
+# Result objects
+##################################################################
+
+sub _err
+{
+	my ($code, $message) = @_;
+	print STDERR "LoxBerry::Auth: $code - $message\n" if ($DEBUG);
+	return { ok => 0, error => $code, message => $message };
+}
+
+##################################################################
+# Token store - data/system/tokens.json, 0600, owner loxberry
+##################################################################
+
+# Test hook: set this to a temp path to decouple tests from the installation
+our $store_file;
+
+sub _store_file
+{
+	return $store_file if ($store_file);
+	if ( defined $LoxBerry::System::lbsdatadir and $LoxBerry::System::lbsdatadir ne '' ) {
+		return "$LoxBerry::System::lbsdatadir/tokens.json";
+	}
+	return "$ENV{LBSDATA}/tokens.json" if ($ENV{LBSDATA});
+	return undef;
+}
+
+sub _store_decode
+{
+	my ($content) = @_;
+	return {} if (!defined $content or $content !~ /\S/);
+	my $data;
+	eval { $data = JSON::from_json($content); };
+	if ($@ or ref($data) ne 'HASH') {
+		print STDERR "LoxBerry::Auth: tokens.json is not readable JSON - starting empty\n" if ($DEBUG);
+		return {};
+	}
+	return $data;
+}
+
+sub _store_encode
+{
+	my ($data) = @_;
+	return JSON->new->pretty->canonical(1)->encode($data);
+}
+
+# Read the full store under a shared lock. A missing file is an empty store
+# and is NOT created here.
+sub _store_read
+{
+	my $file = _store_file();
+	return {} if (!$file or ! -e $file);
+	my $fh;
+	if ( ! CORE::open($fh, '<', $file) ) {
+		print STDERR "LoxBerry::Auth: cannot open $file: $!\n" if ($DEBUG);
+		return {};
+	}
+	flock($fh, LOCK_SH);
+	my $content = do { local $/; <$fh> };
+	close($fh);
+	return _store_decode($content);
+}
+
+# Read-modify-write under ONE exclusive lock. The callback gets the decoded
+# store and mutates it in place. Written only when the content really changed.
+# Returns 1 = written, 0 = unchanged, undef = error.
+sub _store_update
+{
+	my ($cb) = @_;
+	my $file = _store_file();
+	if (!$file) {
+		print STDERR "LoxBerry::Auth: no token store path available\n" if ($DEBUG);
+		return undef;
+	}
+
+	my $fh;
+	if ( ! sysopen($fh, $file, O_RDWR | O_CREAT, 0600) ) {
+		print STDERR "LoxBerry::Auth: cannot open $file: $!\n" if ($DEBUG);
+		return undef;
+	}
+	if ( ! flock($fh, LOCK_EX) ) {
+		print STDERR "LoxBerry::Auth: cannot lock $file: $!\n" if ($DEBUG);
+		close($fh);
+		return undef;
+	}
+
+	my $content = do { local $/; <$fh> };
+	my $data    = _store_decode($content);
+	my $before  = _store_encode($data);
+
+	$cb->($data);
+
+	my $after = _store_encode($data);
+	if ($after eq $before and -s $file) {
+		close($fh);
+		return 0;
+	}
+
+	seek($fh, 0, 0);
+	print $fh $after;
+	truncate($fh, tell($fh));
+	close($fh);   # releases the lock
+
+	chmod 0600, $file;
+	eval {
+		my ($login, $pass, $uid, $gid) = getpwnam("loxberry");
+		chown $uid, $gid, $file if (defined $uid);
+	};
+	return 1;
+}
+
+# Process cache: the token lives in the process, the file is pure persistence
+# across restarts. Another process may change the file behind our back - the
+# single 401 retry in request() is the safety net for that.
+my %tokencache;
+
+sub _cache_clear
+{
+	%tokencache = ();
+	return 1;
+}
+
+sub _store_get_token
+{
+	my ($serial, $user) = @_;
+	return undef if (!$serial or !$user);
+	my $ck = "$serial|$user";
+	return $tokencache{$ck} if (exists $tokencache{$ck});
+
+	my $data = _store_read();
+	return undef if (! exists $data->{$serial});
+	my $tok = $data->{$serial}{users}{$user};
+	$tokencache{$ck} = $tok if ($tok);
+	return $tok;
+}
+
+sub _store_put_token
+{
+	my ($serial, $user, $msmeta, $tokendata) = @_;
+	return undef if (!$serial or !$user);
+	$tokencache{"$serial|$user"} = { %$tokendata };
+	return _store_update( sub {
+		my ($data) = @_;
+		$data->{$serial} = {} if (! exists $data->{$serial});
+		foreach my $k (keys %$msmeta) {
+			$data->{$serial}{$k} = $msmeta->{$k};
+		}
+		$data->{$serial}{users} = {} if (! exists $data->{$serial}{users});
+		$data->{$serial}{users}{$user} = { %$tokendata };
+		return;
+	} );
+}
+
+sub _store_del_token
+{
+	my ($serial, $user) = @_;
+	return undef if (!$serial or !$user);
+	delete $tokencache{"$serial|$user"};
+	return _store_update( sub {
+		my ($data) = @_;
+		delete $data->{$serial}{users}{$user} if (exists $data->{$serial});
+		return;
+	} );
+}
+
+##################################################################
+# Miniserver resolution
+##################################################################
+
+sub _ms_baseurl
+{
+	my ($msc) = @_;
+	return undef if (!$msc);
+	my $transport = $msc->{Transport} ? $msc->{Transport} : 'http';
+	my $port = ($transport eq 'https') ? $msc->{PortHttps} : $msc->{Port};
+	$port = ($transport eq 'https') ? 443 : 80 if (!$port);
+	my $ip = $msc->{IPAddress};
+	$ip = "[$ip]" if (index($ip, ':') != -1);
+	return "$transport://$ip:$port";
+}
+
+# Accepts a Miniserver number or a serial number. A serial is resolved through
+# the token store, which remembers which number it belonged to.
+# Without the user option the credentials from general.json are used. With a
+# user but without a password the password stays undef on purpose - the
+# password from general.json belongs to that user and to no other.
+sub _resolve_ms
+{
+	my ($ms, %opts) = @_;
+	return _err('msnotfound', 'No Miniserver given') if (!defined $ms or $ms eq '');
+
+	my $serial;
+	my $msnr;
+	if ($ms =~ /^\d+$/) {
+		$msnr = $ms;
+	} else {
+		$serial = uc($ms);
+		my $data = _store_read();
+		if ( exists $data->{$serial} and defined $data->{$serial}{msnr} ) {
+			$msnr = $data->{$serial}{msnr};
+		}
+		if (!defined $msnr) {
+			return _err('msnotfound',
+				"Serial $ms is unknown - fetch a token for this Miniserver first");
+		}
+	}
+
+	my %miniservers = LoxBerry::System::get_miniservers();
+	my $msc = $miniservers{$msnr};
+	return _err('msnotfound', "Miniserver $ms is not configured") if (!$msc);
+
+	my $user     = defined $opts{user} ? $opts{user} : $msc->{Admin_RAW};
+	my $password = defined $opts{password} ? $opts{password}
+	             : ( defined $opts{user} ? undef : $msc->{Pass_RAW} );
+
+	return {
+		ok            => 1,
+		msnr          => $msnr,
+		name          => $msc->{Name},
+		baseurl       => _ms_baseurl($msc),
+		user          => $user,
+		password      => $password,
+		serial        => $serial,
+		is_lbsystem   => 1,
+		lbsystem_user => $msc->{Admin_RAW},
+	};
+}
+
+##################################################################
+# general.json: Authmethod (read only - never written by this lib)
+##################################################################
+
+sub auth_method
+{
+	my ($ms) = @_;
+	return 'basicauth' if (!defined $ms or $ms eq '');
+
+	my $msnr = $ms;
+	if ($ms !~ /^\d+$/) {
+		my $data = _store_read();
+		my $serial = uc($ms);
+		$msnr = ( exists $data->{$serial} ) ? $data->{$serial}{msnr} : undef;
+		return 'basicauth' if (!defined $msnr);
+	}
+
+	my $cfg;
+	eval {
+		$cfg = JSON::from_json(
+			LoxBerry::System::read_file("$LoxBerry::System::lbsconfigdir/general.json") );
+	};
+	return 'basicauth' if ($@ or ref($cfg) ne 'HASH');
+
+	my $val = $cfg->{Miniserver}{$msnr}{Authmethod};
+	return 'token' if (defined $val and lc($val) eq 'token');
+	return 'basicauth';
+}
+
+##################################################################
+# HTTP transport
+# Verified on Miniserver 17.1.7.3: jdev/cfg/api and jdev/sys/getkey2
+# answer without any authentication. Only killtoken needs Basic Auth.
+##################################################################
+
+# Test hook: replaced by the unit tests.
+# sub ($url, %opts) -> ($code, $body, $statusline); $code undef = no connection
+our $transport;
+
+sub _http_get
+{
+	my ($url, %opts) = @_;
+	require LWP::UserAgent;
+	my $ua = LWP::UserAgent->new(
+		timeout  => $opts{timeout} ? $opts{timeout} : $TIMEOUT,
+		ssl_opts => { verify_hostname => 0, SSL_verify_mode => 0 },
+	);
+	my @headers;
+	if ( defined $opts{basicauth_user} ) {
+		require MIME::Base64;
+		my $pw = defined $opts{basicauth_password} ? $opts{basicauth_password} : '';
+		push @headers, 'Authorization' => 'Basic '
+			. MIME::Base64::encode_base64( $opts{basicauth_user} . ':' . $pw, '' );
+	}
+	my $resp = $ua->get($url, @headers);
+	# LWP fakes a 500 when the connection never happened - tell that apart
+	my $cw = $resp->header('Client-Warning');
+	if ( defined $cw and $cw eq 'Internal response' ) {
+		return (undef, undef, $resp->status_line);
+	}
+	return ($resp->code, $resp->decoded_content, $resp->status_line);
+}
+
+sub _call
+{
+	my ($url, %opts) = @_;
+	my $t = $transport ? $transport : \&_http_get;
+	print STDERR "LoxBerry::Auth: GET $url\n" if ($DEBUG);
+	return $t->($url, %opts);
+}
+
+# The LL envelope. value is a hashref for most endpoints and a string for
+# jdev/cfg/api. A non-JSON body (the Miniserver answers 401 in HTML) is undef.
+sub _ll_value
+{
+	my ($body) = @_;
+	return undef if (!defined $body or $body !~ /\S/);
+	my $j;
+	eval { $j = JSON::from_json($body); };
+	return undef if ($@ or ref($j) ne 'HASH' or ref($j->{LL}) ne 'HASH');
+	return $j->{LL}{value};
+}
+
+# The LL envelope carries its OWN status code, and the Miniserver does not
+# always mirror it into the HTTP status: refreshjwt answers HTTP 200 with
+# LL.code 401 when the token signature is not accepted. Measured on 17.1.7.3.
+# The field is spelled "Code" by some endpoints (jdev/cfg/api) and "code" by
+# others (jdev/sys/*), so both are read.
+sub _ll_code
+{
+	my ($body) = @_;
+	return undef if (!defined $body or $body !~ /\S/);
+	my $j;
+	eval { $j = JSON::from_json($body); };
+	return undef if ($@ or ref($j) ne 'HASH' or ref($j->{LL}) ne 'HASH');
+	my $c = defined $j->{LL}{code} ? $j->{LL}{code} : $j->{LL}{Code};
+	return undef if (!defined $c or $c !~ /^\d+$/);
+	return int($c);
+}
+
+# The code that really decides: an HTTP 200 carrying a different LL code is a
+# failure, not a success.
+sub _effective_code
+{
+	my ($code, $body) = @_;
+	return $code if (!defined $code or $code != 200);
+	my $ll = _ll_code($body);
+	return $ll if (defined $ll and $ll != 200);
+	return $code;
+}
+
+# Stable per host and user, so the Miniserver does not collect a new client
+# entry on every call. Never persisted - it is derived, not stored.
+sub _client_uuid
+{
+	my ($user) = @_;
+	my $seed = LoxBerry::System::lbhostname() . '|' . $user . '|loxberry-auth';
+	my $h = Digest::SHA::sha256_hex($seed);
+	return join('-', substr($h,0,8), substr($h,8,4), substr($h,12,4),
+	                 substr($h,16,4), substr($h,20,12));
+}
+
+##################################################################
+# Miniserver identity: serial + firmware in one call
+##################################################################
+
+sub _ms_api
+{
+	my ($res, %opts) = @_;
+	my ($code, $body) = _call($res->{baseurl} . '/jdev/cfg/api', %opts);
+	return _err('unreachable', "$res->{baseurl} did not answer") if (!defined $code);
+	$code = _effective_code($code, $body);
+	return _err('httperror', "jdev/cfg/api returned $code") if ($code != 200);
+
+	my $api = _parse_api_value( _ll_value($body) );
+	return _err('parseerror', 'jdev/cfg/api could not be parsed') if (!$api);
+	return _err('parseerror', 'jdev/cfg/api has no serial') if (!$api->{snr});
+
+	return { ok => 1, serial => uc($api->{snr}), firmware => $api->{version} };
+}
+
+sub _getkey2
+{
+	my ($res, $user, %opts) = @_;
+	my $url = $res->{baseurl} . '/jdev/sys/getkey2/' . URI::Escape::uri_escape($user);
+	my ($code, $body) = _call($url, %opts);
+	return _err('unreachable', "$res->{baseurl} did not answer") if (!defined $code);
+	$code = _effective_code($code, $body);
+	return _err('badcredentials', "getkey2 returned $code for user $user") if ($code == 401);
+	return _err('httperror', "getkey2 returned $code") if ($code != 200);
+
+	my $v = _ll_value($body);
+	return _err('parseerror', 'getkey2 could not be parsed') if (ref($v) ne 'HASH');
+	my $alg = _norm_alg( $v->{hashAlg} );
+	return _err('parseerror', "getkey2 returned an unknown hashAlg") if (!$alg);
+	return { ok => 1, key => $v->{key}, salt => $v->{salt}, alg => $alg };
+}
+
+# The serial of a Miniserver number, as far as an earlier run persisted it.
+# Looking it up here keeps get_token free of HTTP when a token is cached -
+# without it every single call would have to ask jdev/cfg/api first.
+sub _serial_from_store
+{
+	my ($msnr) = @_;
+	my $data = _store_read();
+	foreach my $s ( sort keys %$data ) {
+		next if ( !defined $data->{$s}{msnr} or $data->{$s}{msnr} ne $msnr );
+		return ( $s, $data->{$s}{firmware} );
+	}
+	return (undef, undef);
+}
+
+# Like _resolve_ms, but an unknown serial makes every configured Miniserver be
+# asked for its own serial. That is the only way a serial can enter the store.
+sub _resolve_ms_probing
+{
+	my ($ms, %opts) = @_;
+	my $res = _resolve_ms($ms, %opts);
+	return $res if ( $res->{ok} );
+	return $res if ( $ms =~ /^\d+$/ );
+
+	my $want = uc($ms);
+	my %miniservers = LoxBerry::System::get_miniservers();
+	foreach my $msnr ( sort { $a <=> $b } keys %miniservers ) {
+		my $cand = _resolve_ms($msnr, %opts);
+		next if (! $cand->{ok});
+		my $api = _ms_api($cand, %opts);
+		next if (! $api->{ok});
+		next if ( $api->{serial} ne $want );
+		$cand->{serial}   = $want;
+		$cand->{firmware} = $api->{firmware};
+		return $cand;
+	}
+	return _err('msnotfound', "No configured Miniserver has serial $ms");
+}
+
+##################################################################
+# get_token
+##################################################################
+
+sub get_token
+{
+	my ($ms, %opts) = @_;
+
+	my $res = _resolve_ms_probing($ms, %opts);
+	return $res if (! $res->{ok});
+
+	my $user = $res->{user};
+	return _err('nocredentials', "No user for Miniserver $ms") if (!$user);
+
+	my $perm = defined $opts{perm} ? int($opts{perm}) : $DEFAULT_PERM;
+
+	# The serial is stable and may come from the store - that is what keeps a
+	# cached token completely free of HTTP.
+	my $serial   = $res->{serial};
+	my $firmware = $res->{firmware};
+	if (!$serial) {
+		my ($s, $f) = _serial_from_store( $res->{msnr} );
+		$serial   = $s;
+		$firmware = $f if (!$firmware);
+	}
+
+	# Cached token, unless force
+	if (! $opts{force} and $serial) {
+		my $have = _store_get_token($serial, $user);
+		if ( $have and $have->{token} and _rights_granted($have->{rights}, $perm) ) {
+			return {
+				ok         => 1,
+				token      => $have->{token},
+				validUntil => $have->{validUntil},
+				rights     => $have->{rights},
+				perm       => $have->{perm},
+				user       => $user,
+				serial     => $serial,
+				firmware   => $firmware,
+				msnr       => $res->{msnr},
+			};
+		}
+	}
+
+	# Without a password nothing can be fetched - check that before bothering
+	# the Miniserver with a single request.
+	my $password = $res->{password};
+	return _err('nocredentials', "No password available for user $user")
+		if (!defined $password or $password eq '');
+
+	# From here on a token is really fetched. The firmware decides whether that
+	# is allowed at all, and unlike the serial it changes with every Miniserver
+	# update - so it is never taken from the store, always asked fresh.
+	if (! defined $res->{firmware}) {
+		my $api = _ms_api($res, %opts);
+		return $api if (! $api->{ok});
+		$serial   = $api->{serial};
+		$firmware = $api->{firmware};
+	}
+
+	return _err('fwtooold',
+		"Miniserver firmware $firmware is below $MIN_FIRMWARE - tokens would need application encryption")
+		if (! _fw_supported($firmware));
+
+	my $k = _getkey2($res, $user, %opts);
+	return $k if (! $k->{ok});
+
+	my $pwhash   = _pw_hash($password, $k->{salt}, $k->{alg});
+	my $authhash = _auth_hash($user, $pwhash, $k->{key}, $k->{alg});
+	my $info     = defined $opts{info} ? $opts{info} : 'LoxBerry ' . LoxBerry::System::lbhostname();
+
+	my $url = $res->{baseurl} . '/jdev/sys/gettoken/'
+	        . $authhash . '/'
+	        . URI::Escape::uri_escape($user) . '/'
+	        . $perm . '/'
+	        . _client_uuid($user) . '/'
+	        . URI::Escape::uri_escape($info);
+
+	my ($code, $body) = _call($url, %opts);
+	return _err('unreachable', "$res->{baseurl} did not answer") if (!defined $code);
+	$code = _effective_code($code, $body);
+	# A wrong user or password shows up here, NOT at getkey2 - getkey2 answers
+	# 200 even for a user that does not exist.
+	return _err('badcredentials', "gettoken returned 401 for user $user") if ($code == 401);
+	return _err('httperror', "gettoken returned $code") if ($code != 200);
+
+	my $v = _ll_value($body);
+	return _err('parseerror', 'gettoken could not be parsed') if (ref($v) ne 'HASH' or !$v->{token});
+
+	if (! _rights_granted($v->{tokenRights}, $perm)) {
+		return _err('missingright',
+			sprintf("Miniserver granted rights %s, which does not include the requested permission %d (0x%x)",
+			        $v->{tokenRights}, $perm, $perm));
+	}
+
+	my %tokendata = (
+		token      => $v->{token},
+		validUntil => $v->{validUntil},
+		rights     => $v->{tokenRights},
+		perm       => $perm,
+		acquired   => LoxBerry::System::epoch2lox(),
+		info       => $info,
+	);
+	_store_put_token( $serial, $user, {
+		msnr          => $res->{msnr},
+		name          => $res->{name},
+		is_lbsystem   => $res->{is_lbsystem},
+		lbsystem_user => $res->{lbsystem_user},
+		firmware      => $firmware,
+		checked       => LoxBerry::System::epoch2lox(),
+	}, \%tokendata );
+
+	return { ok => 1, %tokendata, user => $user, serial => $serial,
+	         firmware => $firmware, msnr => $res->{msnr} };
+}
+##################################################################
+# token_info / refresh_token / kill_token / request
+##################################################################
+
+# Everything the store knows, plus the remaining lifetime in seconds.
+# No HTTP unless the serial still has to be resolved.
+sub token_info
+{
+	my ($ms, %opts) = @_;
+	my $res = _resolve_ms_probing($ms, %opts);
+	return $res if (! $res->{ok});
+
+	my $serial = $res->{serial};
+	my $data   = _store_read();
+	if (! $serial) {
+		# find the serial belonging to this Miniserver number
+		foreach my $s ( sort keys %$data ) {
+			next if ( !defined $data->{$s}{msnr} or $data->{$s}{msnr} ne $res->{msnr} );
+			$serial = $s;
+			last;
+		}
+	}
+	return _err('notoken', "No token stored for Miniserver $ms") if (!$serial);
+
+	my $have = $data->{$serial}{users}{ $res->{user} };
+	return _err('notoken', "No token stored for user $res->{user}") if (!$have or !$have->{token});
+
+	return {
+		ok         => 1,
+		token      => $have->{token},
+		validUntil => $have->{validUntil},
+		rights     => $have->{rights},
+		perm       => $have->{perm},
+		info       => $have->{info},
+		user       => $res->{user},
+		serial     => $serial,
+		msnr       => $res->{msnr},
+		firmware   => $data->{$serial}{firmware},
+		expires_in => int($have->{validUntil}) - LoxBerry::System::epoch2lox(),
+	};
+}
+
+# refreshjwt works with token authentication only - no password involved.
+# The endpoint answers with a JWT (eyJ0eXAi...) instead of the hex token; both
+# formats are handled the same way from here on.
+sub refresh_token
+{
+	my ($ms, %opts) = @_;
+	my $have = token_info($ms, %opts);
+	return $have if (! $have->{ok});
+
+	my $res = _resolve_ms_probing($ms, %opts);
+	return $res if (! $res->{ok});
+
+	my $k = _getkey2($res, $have->{user}, %opts);
+	return $k if (! $k->{ok});
+	my $hash = _token_hash($have->{token}, $k->{key}, $k->{alg});
+
+	# The path carries the token HASH, autht the PLAIN token. Measured on
+	# 17.1.7.3: hashing both consumes the one-time key twice and the Miniserver
+	# answers HTTP 200 with LL.code 401.
+	my $url = $res->{baseurl} . '/jdev/sys/refreshjwt/' . $hash . '/'
+	        . URI::Escape::uri_escape($have->{user})
+	        . '?autht=' . URI::Escape::uri_escape($have->{token})
+	        . '&user=' . URI::Escape::uri_escape($have->{user});
+
+	my ($code, $body) = _call($url, %opts);
+	return _err('unreachable', "$res->{baseurl} did not answer") if (!defined $code);
+	$code = _effective_code($code, $body);
+	return _err('revoked', "refreshjwt returned 401 - the token was not accepted")
+		if ($code == 401);
+	return _err('httperror', "refreshjwt returned $code") if ($code != 200);
+
+	my $v = _ll_value($body);
+	return _err('parseerror', 'refreshjwt could not be parsed') if (ref($v) ne 'HASH' or !$v->{token});
+
+	my %tokendata = (
+		token      => $v->{token},
+		validUntil => $v->{validUntil},
+		rights     => defined $v->{tokenRights} ? $v->{tokenRights} : $have->{rights},
+		perm       => $have->{perm},
+		acquired   => LoxBerry::System::epoch2lox(),
+		info       => $have->{info},
+	);
+	_store_put_token( $have->{serial}, $have->{user},
+		{ msnr => $res->{msnr}, checked => LoxBerry::System::epoch2lox() }, \%tokendata );
+
+	return { ok => 1, %tokendata, user => $have->{user}, serial => $have->{serial},
+	         firmware => $have->{firmware}, msnr => $res->{msnr} };
+}
+
+# Revoking needs the password: killtoken was measured to work with Basic Auth
+# only, not with token authentication.
+sub kill_token
+{
+	my ($ms, %opts) = @_;
+	my $have = token_info($ms, %opts);
+	return $have if (! $have->{ok});
+
+	my $res = _resolve_ms_probing($ms, %opts);
+	return $res if (! $res->{ok});
+	return _err('nopassword', "kill_token needs the password of user $have->{user}")
+		if (!defined $res->{password} or $res->{password} eq '');
+
+	my $k = _getkey2($res, $have->{user}, %opts);
+	return $k if (! $k->{ok});
+	my $hash = _token_hash($have->{token}, $k->{key}, $k->{alg});
+
+	my $url = $res->{baseurl} . '/jdev/sys/killtoken/' . $hash . '/'
+	        . URI::Escape::uri_escape($have->{user});
+
+	my ($code, $body) = _call($url, %opts,
+		basicauth_user     => $have->{user},
+		basicauth_password => $res->{password} );
+	return _err('unreachable', "$res->{baseurl} did not answer") if (!defined $code);
+	$code = _effective_code($code, $body);
+	return _err('badcredentials', "killtoken returned 401") if ($code == 401);
+	return _err('httperror', "killtoken returned $code") if ($code != 200);
+
+	_store_del_token( $have->{serial}, $have->{user} );
+	return { ok => 1, user => $have->{user}, serial => $have->{serial} };
+}
+
+sub _sign_url
+{
+	my ($baseurl, $command, $token, $user, $res, %opts) = @_;
+	my $k = _getkey2($res, $user, %opts);
+	return (undef, $k) if (! $k->{ok});
+	my $hash = _token_hash($token, $k->{key}, $k->{alg});
+	my $sep = ( index($command, '?') != -1 ) ? '&' : '?';
+	return ( $baseurl . $command . $sep . 'autht=' . $hash
+	         . '&user=' . URI::Escape::uri_escape($user), undef );
+}
+
+# Runs a Miniserver command with token authentication.
+# Returns ($content, \%info) - same keys as LoxBerry::IO::mshttp_call2, plus
+# errcode carrying the error code of this lib.
+sub request
+{
+	my ($ms, $command, %opts) = @_;
+	my %info = ( code => undef, status => undef, error => 1, message => '', errcode => undef );
+
+	my $tok = get_token($ms, %opts);
+	if (! $tok->{ok}) {
+		$info{errcode} = $tok->{error};
+		$info{message} = $tok->{message};
+		return (undef, \%info);
+	}
+
+	# expired -> new token; below the threshold -> renew without a password
+	my $left = int($tok->{validUntil}) - LoxBerry::System::epoch2lox();
+	if ($left <= 0) {
+		$tok = get_token($ms, %opts, force => 1);
+	} elsif ($left < $REFRESH_THRESHOLD) {
+		my $r = refresh_token($ms, %opts);
+		$tok = $r if ( $r->{ok} );
+	}
+	if (! $tok->{ok}) {
+		$info{errcode} = $tok->{error};
+		$info{message} = $tok->{message};
+		return (undef, \%info);
+	}
+
+	my $res = _resolve_ms_probing($ms, %opts);
+	if (! $res->{ok}) {
+		$info{errcode} = $res->{error};
+		$info{message} = $res->{message};
+		return (undef, \%info);
+	}
+
+	foreach my $attempt (1, 2) {
+		my ($url, $urlerr) = _sign_url($res->{baseurl}, $command, $tok->{token},
+		                               $tok->{user}, $res, %opts);
+		if (!$url) {
+			$info{errcode} = $urlerr->{error};
+			$info{message} = $urlerr->{message};
+			return (undef, \%info);
+		}
+
+		my ($code, $body, $status) = _call($url, %opts);
+		if (!defined $code) {
+			$info{errcode} = 'unreachable';
+			$info{message} = "$res->{baseurl} did not answer";
+			return (undef, \%info);
+		}
+
+		$code = _effective_code($code, $body);
+		$info{code}   = $code;
+		$info{status} = $status;
+
+		if ($code == 401) {
+			# The token may have been deleted on the Miniserver although
+			# validUntil still looks fine. Fetch a new one and retry ONCE.
+			if ($attempt == 1) {
+				my $fresh = get_token($ms, %opts, force => 1);
+				if ($fresh->{ok}) {
+					$tok = $fresh;
+					next;
+				}
+				$info{errcode} = $fresh->{error};
+				$info{message} = $fresh->{message};
+				return (undef, \%info);
+			}
+			$info{errcode} = 'revoked';
+			$info{message} = "$command returned 401 twice - the token was revoked";
+			return (undef, \%info);
+		}
+
+		if ($code < 200 or $code >= 300) {
+			$info{errcode} = 'httperror';
+			$info{message} = "$command FAILED - Error $code";
+			return (undef, \%info);
+		}
+
+		$info{error}   = 0;
+		$info{message} = 'Request ok';
+		return ($body, \%info);
+	}
+}
+
+#####################################################
+# Finally 1; ########################################
+#####################################################
+1;

--- a/libs/perllib/LoxBerry/testing/libcompare.pl
+++ b/libs/perllib/LoxBerry/testing/libcompare.pl
@@ -153,4 +153,62 @@ emit('systemloglevel', { value => LoxBerry::System::systemloglevel() });
 	emit('lock_unlock', { lock => $rlock, unlock => $runlock });
 }
 
+#############################################
+# Auth (pure functions)
+#############################################
+{
+	require LoxBerry::Auth;
+
+	my $auth_key  = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+	my $auth_apiv = "{'snr': 'AB:CD:EF:01:02:03', 'version':'17.1.7.3', 'hasEventSlots':true, "
+	              . "'isInTrust':false, 'local':true,'certTLD':'com'}";
+
+	emit('auth_norm_alg', [ map { LoxBerry::Auth::_norm_alg($_) }
+	                        ('SHA256', 'sha-256', 'SHA1', '', 'MD5') ]);
+
+	my $auth_pw256 = LoxBerry::Auth::_pw_hash('Test1234', '41B0A8F1', 'SHA256');
+	my $auth_pw1   = LoxBerry::Auth::_pw_hash('Test1234', '41B0A8F1', 'SHA1');
+	emit('auth_hashes', {
+		pw_sha256    => $auth_pw256,
+		pw_sha1      => $auth_pw1,
+		auth_sha256  => LoxBerry::Auth::_auth_hash('loxberry', $auth_pw256, $auth_key, 'SHA256'),
+		auth_sha1    => LoxBerry::Auth::_auth_hash('loxberry', $auth_pw1, $auth_key, 'SHA1'),
+		token_sha256 => LoxBerry::Auth::_token_hash('a1b2c3d4e5f60718293a4b5c6d7e8f90', $auth_key, 'SHA256'),
+		token_sha1   => LoxBerry::Auth::_token_hash('a1b2c3d4e5f60718293a4b5c6d7e8f90', $auth_key, 'SHA1'),
+	});
+
+	emit('auth_parse_api_value', LoxBerry::Auth::_parse_api_value($auth_apiv));
+
+	emit('auth_fw_supported', [ map { LoxBerry::Auth::_fw_supported($_) }
+	                            ('17.1.7.3', '11.2.10.22', '11.2.10.21', '11.2.9.99', '12.0', '') ]);
+
+	emit('auth_rights_granted', [
+		LoxBerry::Auth::_rights_granted(1924, 0x100),
+		LoxBerry::Auth::_rights_granted(1924, 0x04),
+		LoxBerry::Auth::_rights_granted(4,    0x100),
+		LoxBerry::Auth::_rights_granted(1924, 0x104),
+	]);
+
+	emit('auth_ll_codes', [
+		LoxBerry::Auth::_ll_code('{"LL":{"value":{},"code":"401"}}'),
+		LoxBerry::Auth::_ll_code('{"LL":{"value":"x","Code":"200"}}'),
+		LoxBerry::Auth::_ll_code('<html>401</html>'),
+		LoxBerry::Auth::_effective_code(200, '{"LL":{"value":{},"code":"401"}}'),
+		LoxBerry::Auth::_effective_code(200, '{"LL":{"value":"x","Code":"200"}}'),
+		LoxBerry::Auth::_effective_code(401, '<html>401</html>'),
+	]);
+
+	emit('auth_constants', {
+		default_perm      => $LoxBerry::Auth::DEFAULT_PERM,
+		refresh_threshold => $LoxBerry::Auth::REFRESH_THRESHOLD,
+		min_firmware      => $LoxBerry::Auth::MIN_FIRMWARE,
+		perm_app          => $LoxBerry::Auth::PERM_APP,
+		perm_sysws        => $LoxBerry::Auth::PERM_SYSWS,
+	});
+
+	my %auth_ms = LoxBerry::System::get_miniservers();
+	emit('auth_ms_baseurl', $auth_ms{1} ? LoxBerry::Auth::_ms_baseurl($auth_ms{1}) : undef);
+	emit('auth_auth_method_ms1', LoxBerry::Auth::auth_method(1));
+}
+
 exit 0;

--- a/libs/perllib/LoxBerry/testing/testauth.pl
+++ b/libs/perllib/LoxBerry/testing/testauth.pl
@@ -1,0 +1,124 @@
+#!/usr/bin/perl
+# testauth.pl - LoxBerry::Auth against a real Miniserver.
+# Runs on a live LoxBerry. Analogous to the other testing/ scripts.
+#
+#   perl testauth.pl [msnr|serial] [--store <path>] [--keep]
+#
+# Without --store the token is kept in /tmp, so the productive
+# data/system/tokens.json is not touched.
+# Without --keep the token is revoked at the end - the Miniserver must not
+# collect orphaned tokens in its token list.
+
+use strict;
+use warnings;
+use LoxBerry::System;
+use LoxBerry::Auth;
+
+my $ms    = (defined $ARGV[0] and $ARGV[0] !~ /^--/) ? shift(@ARGV) : 1;
+my $keep  = 0;
+my $store = "/tmp/testauth_tokens.json";
+while (my $a = shift(@ARGV)) {
+	$keep  = 1            if ($a eq '--keep');
+	$store = shift(@ARGV) if ($a eq '--store');
+}
+$LoxBerry::Auth::store_file = $store;
+
+print "Miniserver : $ms\n";
+print "Token store: $store\n";
+print "auth_method: " . LoxBerry::Auth::auth_method($ms) . "\n";
+
+my $failed = 0;
+sub step {
+	my ($name, $res) = @_;
+	if ( ref($res) eq 'HASH' and $res->{ok} ) {
+		print "OK   $name\n";
+		return 1;
+	}
+	$failed++;
+	print "FAIL $name: " . ($res->{error} // '?') . " - " . ($res->{message} // '') . "\n";
+	return 0;
+}
+
+print "\n=== get_token ===\n";
+my $t = LoxBerry::Auth::get_token($ms, info => 'LoxBerry Auth selftest', force => 1);
+if ( step('get_token', $t) ) {
+	printf "     serial     : %s\n", $t->{serial};
+	printf "     firmware   : %s\n", $t->{firmware};
+	printf "     perm       : %d (0x%x)\n", $t->{perm}, $t->{perm};
+	printf "     rights     : %d\n", $t->{rights};
+	printf "     validUntil : %d (lox) = %s\n", $t->{validUntil},
+	       scalar localtime( LoxBerry::System::lox2epoch($t->{validUntil}) );
+	printf "     token      : %s...\n", substr($t->{token}, 0, 12);
+	my $days = ( $t->{validUntil} - LoxBerry::System::epoch2lox() ) / 86400;
+	printf "     lifetime   : %.1f days%s\n", $days,
+	       ($days > 80 ? ' (matches the ~3 months measured for 0x104)' : ' (SHORTER THAN EXPECTED)');
+	printf "     Sys-WS bit : %s\n",
+	       LoxBerry::Auth::_rights_granted($t->{rights}, $LoxBerry::Auth::PERM_SYSWS)
+	       ? 'granted - reboot would be allowed' : 'MISSING';
+}
+
+print "\n=== token_info ===\n";
+my $ti = LoxBerry::Auth::token_info($ms);
+step('token_info', $ti);
+printf "     expires_in : %d s\n", $ti->{expires_in} if ($ti->{ok});
+
+print "\n=== request /jdev/cfg/version ===\n";
+my ($content, $info) = LoxBerry::Auth::request($ms, '/jdev/cfg/version');
+if ( $info->{error} == 0 ) {
+	print "OK   request (code $info->{code})\n";
+	print "     $content\n";
+} else {
+	$failed++;
+	print "FAIL request: " . ($info->{errcode} // '?') . " - $info->{message}\n";
+}
+
+print "\n=== request twice: the one-time key must be fetched again ===\n";
+my (undef, $info2) = LoxBerry::Auth::request($ms, '/jdev/cfg/version');
+if ( $info2->{error} == 0 ) {
+	print "OK   second request (code $info2->{code})\n";
+} else {
+	$failed++;
+	print "FAIL second request: " . ($info2->{errcode} // '?') . " - $info2->{message}\n";
+}
+
+print "\n=== refresh_token (password free) ===\n";
+my $rt = LoxBerry::Auth::refresh_token($ms);
+if ( step('refresh_token', $rt) ) {
+	printf "     token      : %s...\n", substr($rt->{token}, 0, 12);
+	printf "     format     : %s\n", ($rt->{token} =~ /^eyJ/) ? 'JWT' : 'hex';
+	printf "     validUntil : %d\n", $rt->{validUntil};
+}
+
+print "\n=== request with the refreshed token ===\n";
+my (undef, $info3) = LoxBerry::Auth::request($ms, '/jdev/cfg/version');
+if ( $info3->{error} == 0 ) {
+	print "OK   request after refresh (code $info3->{code})\n";
+} else {
+	$failed++;
+	print "FAIL request after refresh: " . ($info3->{errcode} // '?') . " - $info3->{message}\n";
+}
+
+print "\n=== cleanup: kill_token ===\n";
+if ($keep) {
+	print "SKIP --keep given - the token stays on the Miniserver\n";
+} else {
+	my $kt = LoxBerry::Auth::kill_token($ms);
+	step('kill_token', $kt);
+	my $after = LoxBerry::Auth::token_info($ms);
+	if ( !$after->{ok} and $after->{error} eq 'notoken' ) {
+		print "OK   store entry removed\n";
+	} else {
+		$failed++;
+		print "FAIL store entry still present\n";
+	}
+	my (undef, $info4) = LoxBerry::Auth::request($ms, '/jdev/cfg/version');
+	print "     request after kill: code="
+	    . (defined $info4->{code} ? $info4->{code} : 'none')
+	    . " errcode=" . ($info4->{errcode} // 'none')
+	    . " (a fresh token is fetched automatically - that is correct)\n";
+	# the automatically re-fetched token has to go as well
+	LoxBerry::Auth::kill_token($ms);
+}
+
+print "\n" . ($failed ? "$failed STEP(S) FAILED\n" : "ALL STEPS OK\n");
+exit( $failed ? 1 : 0 );

--- a/libs/perllib/t/auth_flows.t
+++ b/libs/perllib/t/auth_flows.t
@@ -1,0 +1,366 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use File::Spec;
+use File::Path qw( make_path );
+
+my $home;
+BEGIN {
+	require File::Temp;
+	$home = File::Temp::tempdir( CLEANUP => 1 );
+	$ENV{LBHOMEDIR} = $home;
+}
+
+make_path("$home/config/system");
+make_path("$home/data/system");
+
+open( my $gfh, '>', "$home/config/system/general.json" ) or die $!;
+print $gfh <<'GENERALJSON';
+{
+  "Base": { "Lang": "de", "Version": "4.0.0.15" },
+  "Miniserver": {
+    "1": {
+      "Name": "Miniserver", "Ipaddress": "192.0.2.10",
+      "Admin": "loxberry", "Pass": "TestPass%2123",
+      "Credentials": "loxberry:TestPass%2123",
+      "Admin_raw": "loxberry", "Pass_raw": "TestPass!23",
+      "Credentials_raw": "loxberry:TestPass!23",
+      "Port": 80, "Porthttps": 443, "Preferhttps": 0
+    }
+  }
+}
+GENERALJSON
+close($gfh);
+
+use lib File::Spec->catdir( $FindBin::Bin, '..' );
+use LoxBerry::Auth;
+
+$LoxBerry::Auth::store_file = "$home/data/system/tokens.json";
+
+# --- Fake-Transport --------------------------------------------------------
+my $KEY  = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+my $SALT = '41B0A8F1';
+my @calls;
+my %behaviour = (
+	api_fw          => '17.1.7.3',
+	api_serial      => 'AB:CD:EF:01:02:03',
+	gettoken        => 'ok',       # ok | 401 | unreachable
+	rights          => 1924,
+	validUntil      => 999999999,
+	unreachable_all => 0,
+);
+
+my $API_BODY = sub {
+	my $v = "{'snr': '$behaviour{api_serial}', 'version':'$behaviour{api_fw}', "
+	      . "'hasEventSlots':true, 'isInTrust':false, 'local':true,'certTLD':'com'}";
+	return '{"LL": { "control": "dev/cfg/api", "value": "' . $v . '", "Code": "200"}}';
+};
+
+$LoxBerry::Auth::transport = sub {
+	my ($url, %o) = @_;
+	push @calls, $url;
+	return (undef, undef, 'Connection refused') if ($behaviour{unreachable_all});
+
+	if ($url =~ m{/jdev/cfg/api$}) {
+		return (200, $API_BODY->(), '200 OK');
+	}
+	if ($url =~ m{/jdev/sys/getkey2/}) {
+		return (200, '{"LL":{"control":"dev/sys/getkey2","code":"200","value":'
+		           . '{"key":"' . $KEY . '","salt":"' . $SALT . '","hashAlg":"SHA256"}}}', '200 OK');
+	}
+	if ($url =~ m{/jdev/sys/gettoken/}) {
+		return (undef, undef, 'Connection refused') if ($behaviour{gettoken} eq 'unreachable');
+		if ($behaviour{gettoken} eq '401') {
+			return (401, '<html><head><title>error</title></head><body><errorcode>401</errorcode>'
+			           . '</body></html>', '401 Unauthorized');
+		}
+		return (200, '{"LL":{"control":"dev/sys/gettoken","code":"200","value":'
+		           . '{"token":"tokTESTVALUE123","key":"' . $KEY . '","validUntil":'
+		           . $behaviour{validUntil} . ',"tokenRights":' . $behaviour{rights}
+		           . ',"unsecurePass":false}}}', '200 OK');
+	}
+	return (404, 'not found', '404 Not Found');
+};
+
+# --- _ll_value -------------------------------------------------------------
+is( LoxBerry::Auth::_ll_value('{"LL":{"value":{"a":1},"Code":"200"}}')->{a}, 1, 'll_value Hashref' );
+is( LoxBerry::Auth::_ll_value('{"LL":{"value":"text","Code":"200"}}'), 'text', 'll_value String' );
+is( LoxBerry::Auth::_ll_value('<html>kaputt</html>'), undef, 'll_value auf HTML ist undef' );
+is( LoxBerry::Auth::_ll_value(''), undef, 'll_value auf leer ist undef' );
+
+# --- _client_uuid ----------------------------------------------------------
+my $uuid = LoxBerry::Auth::_client_uuid('loxberry');
+like( $uuid, qr/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/, 'client_uuid hat UUID-Form' );
+is( LoxBerry::Auth::_client_uuid('loxberry'), $uuid, 'client_uuid ist stabil' );
+isnt( LoxBerry::Auth::_client_uuid('sortmgr'), $uuid, 'client_uuid je Benutzer verschieden' );
+
+# --- _ms_api ---------------------------------------------------------------
+my $res = LoxBerry::Auth::_resolve_ms(1);
+my $api = LoxBerry::Auth::_ms_api($res);
+is( $api->{ok},       1,                   'ms_api ok' );
+is( $api->{serial},   'AB:CD:EF:01:02:03', 'Seriennummer aus cfg/api' );
+is( $api->{firmware}, '17.1.7.3',          'Firmware aus cfg/api' );
+
+# --- get_token, Gutfall ----------------------------------------------------
+@calls = ();
+my $t = LoxBerry::Auth::get_token(1);
+is( $t->{ok},         1,                   'get_token ok' );
+is( $t->{token},      'tokTESTVALUE123',   'Token' );
+is( $t->{validUntil}, 999999999,           'validUntil' );
+is( $t->{rights},     1924,                'rights' );
+is( $t->{perm},       260,                 'perm ist der Standard 0x104 = 260' );
+is( $t->{user},       'loxberry',          'Benutzer' );
+is( $t->{serial},     'AB:CD:EF:01:02:03', 'Seriennummer' );
+is( $t->{firmware},   '17.1.7.3',          'Firmware' );
+
+# Der authHash im gettoken-Aufruf muss exakt stimmen
+# pw=TestPass!23 salt=41B0A8F1 alg=SHA256 key=0123..ef
+my ($gettoken_url) = grep { m{/jdev/sys/gettoken/} } @calls;
+like( $gettoken_url,
+      qr{/jdev/sys/gettoken/6811aac909afa7d530fd1cf87a28e4a9db15ad4e99eea57b33944319b05a86c5/loxberry/260/},
+      'authHash, Benutzer und perm stehen korrekt in der URL' );
+like( $gettoken_url, qr{/LoxBerry(%20|\+)}, 'info-Feld beginnt mit LoxBerry' );
+
+# getkey2 wurde vor gettoken geholt
+my @order = map { m{/jdev/sys/(\w+)/} ? $1 : () } @calls;
+is_deeply( [ grep { /^(getkey2|gettoken)$/ } @order ], [ 'getkey2', 'gettoken' ],
+           'getkey2 wird unmittelbar vor gettoken geholt' );
+
+# --- Persistenz ------------------------------------------------------------
+my $stored = LoxBerry::Auth::_store_get_token('AB:CD:EF:01:02:03', 'loxberry');
+is( $stored->{token},  'tokTESTVALUE123', 'Token persistiert' );
+is( $stored->{rights}, 1924,              'rights persistiert' );
+ok( ! exists $stored->{key},      'Einmalschluessel nicht persistiert' );
+ok( ! exists $stored->{password}, 'Passwort nicht persistiert' );
+
+# --- Zweiter Aufruf nimmt den Bestand --------------------------------------
+@calls = ();
+my $t2 = LoxBerry::Auth::get_token(1);
+is( $t2->{token}, 'tokTESTVALUE123', 'zweiter Aufruf liefert denselben Token' );
+is( scalar(@calls), 0, 'zweiter Aufruf macht keinen einzigen HTTP-Request' );
+
+# --- force erzwingt einen neuen Token --------------------------------------
+@calls = ();
+LoxBerry::Auth::get_token(1, force => 1);
+ok( scalar(@calls) >= 2, 'force holt neu' );
+
+# --- Aufloesung ueber die Seriennummer klappt jetzt ------------------------
+my $ts = LoxBerry::Auth::get_token('AB:CD:EF:01:02:03');
+is( $ts->{ok}, 1, 'get_token ueber die Seriennummer' );
+
+# --- Fehlendes Recht -------------------------------------------------------
+$behaviour{rights} = 4;    # nur App, kein Sys-WS
+my $tr = LoxBerry::Auth::get_token(1, force => 1);
+is( $tr->{ok},    0,              'fehlendes Recht ist ein Fehler' );
+is( $tr->{error}, 'missingright', 'Fehlercode missingright' );
+like( $tr->{message}, qr/0x104|260/, 'Meldung nennt die angeforderte Permission' );
+$behaviour{rights} = 1924;
+
+# --- 401 bei gettoken ------------------------------------------------------
+$behaviour{gettoken} = '401';
+my $tb = LoxBerry::Auth::get_token(1, force => 1);
+is( $tb->{ok},    0,                'falsche Zugangsdaten sind ein Fehler' );
+is( $tb->{error}, 'badcredentials', 'Fehlercode badcredentials - der 401 kommt bei gettoken, nicht bei getkey2' );
+$behaviour{gettoken} = 'ok';
+
+# --- Firmware zu alt -------------------------------------------------------
+$behaviour{api_fw} = '11.2.10.21';
+@calls = ();
+my $tf = LoxBerry::Auth::get_token(1, force => 1);
+is( $tf->{ok},    0,          'zu alte Firmware ist ein Fehler' );
+is( $tf->{error}, 'fwtooold', 'Fehlercode fwtooold' );
+is( scalar( grep { m{/jdev/sys/} } @calls ), 0, 'bei zu alter Firmware wird kein Token angefragt' );
+$behaviour{api_fw} = '17.1.7.3';
+
+# --- Miniserver nicht erreichbar -------------------------------------------
+$behaviour{unreachable_all} = 1;
+my $tu = LoxBerry::Auth::get_token(1, force => 1);
+is( $tu->{ok},    0,             'nicht erreichbar ist ein Fehler' );
+is( $tu->{error}, 'unreachable', 'Fehlercode unreachable' );
+$behaviour{unreachable_all} = 0;
+
+# --- Kein Passwort ---------------------------------------------------------
+@calls = ();
+my $tn = LoxBerry::Auth::get_token(1, user => 'sortmgr');
+is( $tn->{ok},    0,               'fremder Benutzer ohne Passwort ist ein Fehler' );
+is( $tn->{error}, 'nocredentials', 'Fehlercode nocredentials' );
+is( scalar(@calls), 0, 'ohne Passwort wird gar nicht erst gefragt' );
+
+# --- Fremder Benutzer mit Passwort -----------------------------------------
+my $tx = LoxBerry::Auth::get_token(1, user => 'sortmgr', password => 'geheim', perm => 0x04);
+is( $tx->{ok},   1,         'fremder Benutzer mit Passwort bekommt einen Token' );
+is( $tx->{perm}, 4,         'uebergebene Permission wird verwendet' );
+is( $tx->{user}, 'sortmgr', 'Token gehoert dem fremden Benutzer' );
+is( LoxBerry::Auth::_store_get_token('AB:CD:EF:01:02:03', 'sortmgr')->{token},
+    'tokTESTVALUE123', 'zweiter Benutzer steht neben dem ersten im Bestand' );
+
+
+# ==========================================================================
+# Task 5: request / token_info / refresh_token / kill_token
+# ==========================================================================
+
+my $TOKHASH = '3b50109633af4140485302f72bd8a2734950286ca29a4633ef6c54376540bd69';
+my @optlog;
+$behaviour{refresh}      = 'ok';   # ok | 401
+$behaviour{kill}         = 'ok';   # ok | 401
+$behaviour{cmd_401_once} = 0;
+
+my $base_transport = $LoxBerry::Auth::transport;
+$LoxBerry::Auth::transport = sub {
+	my ($url, %o) = @_;
+	push @optlog, { url => $url, opts => { %o } };
+
+	if ($url =~ m{/jdev/sys/refreshjwt/}) {
+		push @calls, $url;
+		return (401, '<html>401</html>', '401 Unauthorized') if ($behaviour{refresh} eq '401');
+		# Am echten Miniserver gemessen: HTTP 200, aber LL.code 401
+		return (200, '{"LL":{"control":"dev/sys/refreshjwt","value":{},"code":"401"}}', '200 OK')
+			if ($behaviour{refresh} eq 'll401');
+		return (200, '{"LL":{"control":"dev/sys/refreshjwt","code":"200","value":'
+		           . '{"token":"eyJ0eXAiTESTJWT","validUntil":' . $behaviour{validUntil}
+		           . ',"tokenRights":1924,"unsecurePass":false}}}', '200 OK');
+	}
+	if ($url =~ m{/jdev/sys/killtoken/}) {
+		push @calls, $url;
+		return (401, '<html>401</html>', '401 Unauthorized') if ($behaviour{kill} eq '401');
+		return (200, '{"LL":{"control":"dev/sys/killtoken","code":"200","value":"1"}}', '200 OK');
+	}
+	if ($url =~ m{autht=}) {
+		push @calls, $url;
+		if ($behaviour{cmd_401_once}) {
+			$behaviour{cmd_401_once}--;
+			return (401, '<html>401</html>', '401 Unauthorized');
+		}
+		return (200, '{"LL":{"control":"dev/sps/io/Test","code":"200","value":"42"}}', '200 OK');
+	}
+	return $base_transport->($url, %o);
+};
+
+# Ausgangslage: frischer, lange gueltiger Token fuer loxberry
+LoxBerry::Auth::_store_put_token('AB:CD:EF:01:02:03', 'loxberry',
+	{ msnr => 1, name => 'Miniserver', firmware => '17.1.7.3' },
+	{ token => 'tokTESTVALUE123', validUntil => LoxBerry::System::epoch2lox() + 60*86400,
+	  rights => 1924, perm => 260, acquired => 1, info => 'LoxBerry testhost' } );
+
+# --- token_info ------------------------------------------------------------
+@calls = ();
+my $ti = LoxBerry::Auth::token_info(1);
+is( $ti->{ok},     1,                   'token_info ok' );
+is( $ti->{token},  'tokTESTVALUE123',   'token_info Token' );
+is( $ti->{rights}, 1924,                'token_info rights' );
+is( $ti->{user},   'loxberry',          'token_info Benutzer' );
+is( $ti->{serial}, 'AB:CD:EF:01:02:03', 'token_info Seriennummer' );
+cmp_ok( $ti->{expires_in}, '>', 59*86400, 'token_info Restlaufzeit in Sekunden' );
+is( LoxBerry::Auth::token_info(1, user => 'niemand')->{error}, 'notoken',
+    'token_info ohne Bestand ist notoken' );
+
+# --- request, Gutfall ------------------------------------------------------
+@calls = ();
+my ($content, $info) = LoxBerry::Auth::request(1, '/jdev/sps/io/Test');
+is( $info->{code},  200, 'request code 200' );
+is( $info->{error}, 0,   'request error 0' );
+like( $content, qr/"value":"42"/, 'request liefert den Body' );
+
+my ($cmd_url) = grep { m{/jdev/sps/io/Test} } @calls;
+like( $cmd_url, qr{\?autht=\Q$TOKHASH\E&user=loxberry$},
+      'autht traegt den Token-Hash, user haengt an' );
+
+# getkey2 wird vor JEDEM signierten Request neu geholt - der Schluessel ist einmalig
+@calls = ();
+LoxBerry::Auth::request(1, '/jdev/sps/io/Test');
+is( scalar( grep { m{/jdev/sys/getkey2/} } @calls ), 1,
+    'jeder Request holt genau einen frischen Einmalschluessel' );
+
+# --- Kommando mit eigenem Query-String -------------------------------------
+@calls = ();
+LoxBerry::Auth::request(1, '/jdev/sps/io/Test?state=on');
+my ($q_url) = grep { m{/jdev/sps/io/Test} } @calls;
+like( $q_url, qr{\?state=on&autht=}, 'vorhandener Query-String wird mit & ergaenzt' );
+
+# --- 401: einmal neu beschaffen und wiederholen ----------------------------
+@calls = ();
+$behaviour{cmd_401_once} = 1;
+my ($c2, $i2) = LoxBerry::Auth::request(1, '/jdev/sps/io/Test');
+is( $i2->{code},  200, '401 fuehrt zu einem erfolgreichen zweiten Versuch' );
+is( $i2->{error}, 0,   'kein Fehler nach dem Wiederholen' );
+is( scalar( grep { m{/jdev/sys/gettoken/} } @calls ), 1,
+    'genau ein neuer Token wird beschafft' );
+
+# --- 401 auch beim zweiten Versuch -----------------------------------------
+@calls = ();
+$behaviour{cmd_401_once} = 2;
+my ($c3, $i3) = LoxBerry::Auth::request(1, '/jdev/sps/io/Test');
+is( $i3->{error},   1,         'zweimal 401 bleibt ein Fehler' );
+is( $i3->{errcode}, 'revoked', 'Fehlercode revoked' );
+is( $c3, undef, 'kein Inhalt bei revoked' );
+$behaviour{cmd_401_once} = 0;
+
+# --- Abgelaufener Token wird neu beschafft ---------------------------------
+LoxBerry::Auth::_store_put_token('AB:CD:EF:01:02:03', 'loxberry',
+	{ msnr => 1 },
+	{ token => 'tokTESTVALUE123', validUntil => LoxBerry::System::epoch2lox() - 10,
+	  rights => 1924, perm => 260, acquired => 1, info => 'x' } );
+@calls = ();
+LoxBerry::Auth::request(1, '/jdev/sps/io/Test');
+is( scalar( grep { m{/jdev/sys/gettoken/} } @calls ), 1,
+    'abgelaufener Token wird neu beschafft' );
+is( scalar( grep { m{/jdev/sys/refreshjwt/} } @calls ), 0,
+    'abgelaufener Token wird nicht erneuert, sondern neu geholt' );
+
+# --- Token unter der Schwelle wird erneuert --------------------------------
+LoxBerry::Auth::_store_put_token('AB:CD:EF:01:02:03', 'loxberry',
+	{ msnr => 1 },
+	{ token => 'tokTESTVALUE123', validUntil => LoxBerry::System::epoch2lox() + 3*86400,
+	  rights => 1924, perm => 260, acquired => 1, info => 'x' } );
+@calls = ();
+LoxBerry::Auth::request(1, '/jdev/sps/io/Test');
+is( scalar( grep { m{/jdev/sys/refreshjwt/} } @calls ), 1,
+    'Restlaufzeit unter 7 Tagen loest refreshjwt aus' );
+is( scalar( grep { m{/jdev/sys/gettoken/} } @calls ), 0,
+    'Erneuerung braucht kein gettoken und kein Passwort' );
+is( LoxBerry::Auth::_store_get_token('AB:CD:EF:01:02:03', 'loxberry')->{token},
+    'eyJ0eXAiTESTJWT', 'der erneuerte JWT ersetzt den alten Token im Bestand' );
+
+# --- refresh_token direkt --------------------------------------------------
+my $rt = LoxBerry::Auth::refresh_token(1);
+is( $rt->{ok},    1,                 'refresh_token ok' );
+is( $rt->{token}, 'eyJ0eXAiTESTJWT', 'refresh_token liefert den JWT' );
+is( LoxBerry::Auth::refresh_token(1, user => 'niemand')->{error}, 'notoken',
+    'refresh_token ohne Bestand ist notoken' );
+
+$behaviour{refresh} = '401';
+is( LoxBerry::Auth::refresh_token(1)->{error}, 'revoked',
+    '401 bei refreshjwt bedeutet: Token serverseitig widerrufen' );
+
+# Der Miniserver spiegelt den LL-Code NICHT immer in den HTTP-Status - am
+# echten Geraet antwortet refreshjwt mit HTTP 200 und LL.code 401.
+$behaviour{refresh} = 'll401';
+is( LoxBerry::Auth::refresh_token(1)->{error}, 'revoked',
+    'HTTP 200 mit LL-Code 401 wird als Ablehnung erkannt' );
+$behaviour{refresh} = 'ok';
+
+# autht traegt den Klartext-Token, der Pfad den Hash
+@calls = ();
+LoxBerry::Auth::refresh_token(1);
+my ($rj_url) = grep { m{/jdev/sys/refreshjwt/} } @calls;
+like( $rj_url, qr{/jdev/sys/refreshjwt/[0-9a-f]{64}/loxberry\?autht=},
+      'refreshjwt: Token-Hash im Pfad' );
+unlike( $rj_url, qr{autht=[0-9a-f]{64}&}, 'refreshjwt: autht ist NICHT der Hash' );
+like( $rj_url, qr{autht=eyJ0eXAiTESTJWT&}, 'refreshjwt: autht ist der Klartext-Token' );
+
+# --- kill_token ------------------------------------------------------------
+is( LoxBerry::Auth::kill_token(1, user => 'sortmgr')->{error}, 'nopassword',
+    'kill_token ohne Passwort ist nopassword' );
+
+@optlog = ();
+my $kt = LoxBerry::Auth::kill_token(1);
+is( $kt->{ok}, 1, 'kill_token mit dem Passwort aus general.json' );
+my ($killcall) = grep { $_->{url} =~ m{/jdev/sys/killtoken/} } @optlog;
+is( $killcall->{opts}{basicauth_user},     'loxberry',   'killtoken nutzt Basic-Auth' );
+is( $killcall->{opts}{basicauth_password}, 'TestPass!23', 'Basic-Auth mit dem Klartext-Passwort' );
+is( LoxBerry::Auth::_store_get_token('AB:CD:EF:01:02:03', 'loxberry'), undef,
+    'nach kill_token ist der Eintrag aus dem Bestand entfernt' );
+
+done_testing();

--- a/libs/perllib/t/auth_ms.t
+++ b/libs/perllib/t/auth_ms.t
@@ -1,0 +1,123 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use File::Spec;
+use File::Path qw( make_path );
+
+my $home;
+BEGIN {
+	# LoxBerry::System liest LBHOMEDIR beim Laden - daher hier, vor dem use
+	require File::Temp;
+	$home = File::Temp::tempdir( CLEANUP => 1 );
+	$ENV{LBHOMEDIR} = $home;
+}
+
+make_path("$home/config/system");
+make_path("$home/data/system");
+
+open( my $gfh, '>', "$home/config/system/general.json" ) or die $!;
+print $gfh <<'GENERALJSON';
+{
+  "Base": { "Lang": "de", "Version": "4.0.0.15" },
+  "Miniserver": {
+    "1": {
+      "Name": "Miniserver", "Ipaddress": "192.0.2.10",
+      "Admin": "loxberry", "Pass": "TestPass%2123",
+      "Credentials": "loxberry:TestPass%2123",
+      "Admin_raw": "loxberry", "Pass_raw": "TestPass!23",
+      "Credentials_raw": "loxberry:TestPass!23",
+      "Port": 80, "Porthttps": 443, "Preferhttps": 0
+    },
+    "2": {
+      "Name": "MS Secure", "Ipaddress": "192.0.2.11",
+      "Admin": "admin", "Pass": "secret",
+      "Credentials": "admin:secret",
+      "Admin_raw": "admin", "Pass_raw": "secret",
+      "Credentials_raw": "admin:secret",
+      "Port": 80, "Porthttps": 4443, "Preferhttps": 1,
+      "Authmethod": "token"
+    },
+    "3": {
+      "Name": "MS IPv6", "Ipaddress": "fe80::1",
+      "Admin": "admin", "Pass": "secret",
+      "Credentials": "admin:secret",
+      "Admin_raw": "admin", "Pass_raw": "secret",
+      "Credentials_raw": "admin:secret",
+      "Port": 80, "Porthttps": 443, "Preferhttps": 0,
+      "Authmethod": "basicauth"
+    }
+  }
+}
+GENERALJSON
+close($gfh);
+
+use lib File::Spec->catdir( $FindBin::Bin, '..' );
+use LoxBerry::Auth;
+
+$LoxBerry::Auth::store_file = "$home/data/system/tokens.json";
+
+# --- _err ------------------------------------------------------------------
+my $e = LoxBerry::Auth::_err('unreachable', 'timed out');
+is( $e->{ok},      0,             'err ok ist 0' );
+is( $e->{error},   'unreachable', 'err code' );
+is( $e->{message}, 'timed out',   'err message' );
+
+# --- _resolve_ms per Nummer ------------------------------------------------
+my $r = LoxBerry::Auth::_resolve_ms(1);
+is( $r->{ok},       1,                           'resolve MS 1 ok' );
+is( $r->{msnr},     1,                           'msnr' );
+is( $r->{name},     'Miniserver',                'name' );
+is( $r->{baseurl},  'http://192.0.2.10:80',   'baseurl http' );
+is( $r->{user},     'loxberry',                  'Benutzer aus general.json' );
+is( $r->{password}, 'TestPass!23',                'Passwort aus Pass_raw, nicht aus Pass' );
+is( $r->{lbsystem_user}, 'loxberry',             'lbsystem_user' );
+
+my $r2 = LoxBerry::Auth::_resolve_ms(2);
+is( $r2->{baseurl}, 'https://192.0.2.11:4443', 'baseurl https mit eigenem Port' );
+
+my $r3 = LoxBerry::Auth::_resolve_ms(3);
+is( $r3->{baseurl}, 'http://[fe80::1]:80',        'IPv6 in eckigen Klammern' );
+
+# --- Benutzer und Passwort per Option --------------------------------------
+my $ru = LoxBerry::Auth::_resolve_ms(1, user => 'sortmgr', password => 'geheim');
+is( $ru->{user},     'sortmgr', 'uebergebener Benutzer' );
+is( $ru->{password}, 'geheim',  'uebergebenes Passwort' );
+
+my $rnp = LoxBerry::Auth::_resolve_ms(1, user => 'sortmgr');
+is( $rnp->{user},     'sortmgr', 'uebergebener Benutzer ohne Passwort' );
+is( $rnp->{password}, undef,     'kein Rueckfall auf das Passwort aus general.json' );
+
+# --- Unbekannter Miniserver ------------------------------------------------
+my $rn = LoxBerry::Auth::_resolve_ms(9);
+is( $rn->{ok},    0,            'MS 9 nicht konfiguriert' );
+is( $rn->{error}, 'msnotfound', 'Fehlercode msnotfound' );
+is( LoxBerry::Auth::_resolve_ms(undef)->{error}, 'msnotfound', 'undef ist msnotfound' );
+is( LoxBerry::Auth::_resolve_ms('')->{error},    'msnotfound', 'leer ist msnotfound' );
+
+# --- Aufloesung ueber die Seriennummer -------------------------------------
+is( LoxBerry::Auth::_resolve_ms('AB:CD:EF:01:02:03')->{error}, 'msnotfound',
+    'unbekannte Seriennummer ist msnotfound' );
+
+LoxBerry::Auth::_store_put_token('AB:CD:EF:01:02:03', 'loxberry',
+	{ msnr => 1, name => 'Miniserver', firmware => '17.1.7.3' },
+	{ token => 'abc', validUntil => 1, rights => 1924 } );
+
+my $rs = LoxBerry::Auth::_resolve_ms('AB:CD:EF:01:02:03');
+is( $rs->{ok},      1,                         'bekannte Seriennummer loest auf' );
+is( $rs->{msnr},    1,                         'Seriennummer -> msnr 1' );
+is( $rs->{serial},  'AB:CD:EF:01:02:03',       'serial durchgereicht' );
+is( $rs->{baseurl}, 'http://192.0.2.10:80', 'baseurl aus general.json' );
+is( LoxBerry::Auth::_resolve_ms('ab:cd:ef:01:02:03')->{msnr}, 1,
+    'Seriennummer wird gross geschrieben verglichen' );
+
+# --- auth_method -----------------------------------------------------------
+is( LoxBerry::Auth::auth_method(1), 'basicauth', 'fehlender Authmethod-Schluessel ist basicauth' );
+is( LoxBerry::Auth::auth_method(2), 'token',     'Authmethod token' );
+is( LoxBerry::Auth::auth_method(3), 'basicauth', 'Authmethod basicauth' );
+is( LoxBerry::Auth::auth_method(9), 'basicauth', 'unbekannter Miniserver ist basicauth' );
+is( LoxBerry::Auth::auth_method('AB:CD:EF:01:02:03'), 'basicauth',
+    'auth_method ueber die Seriennummer' );
+
+done_testing();

--- a/libs/perllib/t/auth_pure.t
+++ b/libs/perllib/t/auth_pure.t
@@ -1,0 +1,73 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use File::Spec;
+
+# LoxBerry/ liegt neben t/ unterhalb von libs/perllib/
+use lib File::Spec->catdir( $FindBin::Bin, '..' );
+use LoxBerry::Auth;
+
+# --- _norm_alg -------------------------------------------------------------
+is( LoxBerry::Auth::_norm_alg('SHA256'),  'SHA256', 'norm_alg SHA256' );
+is( LoxBerry::Auth::_norm_alg('sha-256'), 'SHA256', 'norm_alg sha-256 normalisiert' );
+is( LoxBerry::Auth::_norm_alg('SHA1'),    'SHA1',   'norm_alg SHA1' );
+is( LoxBerry::Auth::_norm_alg(undef),     'SHA1',   'norm_alg leer faellt auf SHA1 zurueck' );
+is( LoxBerry::Auth::_norm_alg('MD5'),     undef,    'norm_alg unbekannt ist undef' );
+
+# --- Hash-Kette gegen feste Referenzwerte ---------------------------------
+# user=loxberry pw=Test1234 salt=41B0A8F1 token=a1b2c3d4e5f60718293a4b5c6d7e8f90
+my $KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+my $pw256 = LoxBerry::Auth::_pw_hash('Test1234', '41B0A8F1', 'SHA256');
+is( $pw256, '3E4A5D209675FD7633320D7F1AA5B399174D2B397ABE4FE53118FCECE38A847D',
+    'pw_hash SHA256 gross geschrieben und korrekt' );
+is( LoxBerry::Auth::_auth_hash('loxberry', $pw256, $KEY, 'SHA256'),
+    '31db6348ae60d52f53381bc3ebf2b7b1691a55e51110ef31ac50b19b1b2f9f47',
+    'auth_hash SHA256' );
+is( LoxBerry::Auth::_token_hash('a1b2c3d4e5f60718293a4b5c6d7e8f90', $KEY, 'SHA256'),
+    '7c75d4ea7111e124200e9939ded8f9d2ece6835089a4d5ff1fb6d96e57b6dd65',
+    'token_hash SHA256' );
+
+my $pw1 = LoxBerry::Auth::_pw_hash('Test1234', '41B0A8F1', 'SHA1');
+is( $pw1, '3A09820F277977B59FE88D032BBC7ECF5C2C7BCD', 'pw_hash SHA1' );
+is( LoxBerry::Auth::_auth_hash('loxberry', $pw1, $KEY, 'SHA1'),
+    'dde0f27175043736346411f693364a2bee2c0308', 'auth_hash SHA1' );
+is( LoxBerry::Auth::_token_hash('a1b2c3d4e5f60718293a4b5c6d7e8f90', $KEY, 'SHA1'),
+    '9135606ae0eac2862b8536f0adc059cf57fd7e62', 'token_hash SHA1' );
+
+# --- _parse_api_value ------------------------------------------------------
+# jdev/cfg/api liefert value als STRING mit einfachen Anfuehrungszeichen -
+# kein gueltiges JSON. Originalantwort von Miniserver 17.1.7.3:
+my $apival = "{'snr': 'AB:CD:EF:01:02:03', 'version':'17.1.7.3', 'hasEventSlots':true, "
+           . "'isInTrust':false, 'local':true,'certTLD':'com'}";
+my $api = LoxBerry::Auth::_parse_api_value($apival);
+is( $api->{snr},     'AB:CD:EF:01:02:03', 'parse_api_value snr' );
+is( $api->{version}, '17.1.7.3',          'parse_api_value version' );
+is( $api->{certTLD}, 'com',               'parse_api_value certTLD' );
+is( $api->{local},   'true',              'parse_api_value unquotierter Wert' );
+is( LoxBerry::Auth::_parse_api_value(''),    undef, 'parse_api_value leer' );
+is( LoxBerry::Auth::_parse_api_value(undef), undef, 'parse_api_value undef' );
+
+# --- _fw_supported ---------------------------------------------------------
+is( LoxBerry::Auth::_fw_supported('17.1.7.3'),   1, 'fw 17.1.7.3 unterstuetzt' );
+is( LoxBerry::Auth::_fw_supported('11.2.10.22'), 1, 'fw exakt am Floor unterstuetzt' );
+is( LoxBerry::Auth::_fw_supported('11.2.10.21'), 0, 'fw knapp unter Floor abgelehnt' );
+is( LoxBerry::Auth::_fw_supported('11.2.9.99'),  0, 'fw aeltere Patchlinie abgelehnt' );
+is( LoxBerry::Auth::_fw_supported('12.0'),       1, 'fw mit weniger Stellen unterstuetzt' );
+is( LoxBerry::Auth::_fw_supported(''),           0, 'fw leer abgelehnt' );
+
+# --- _rights_granted -------------------------------------------------------
+# perm 0x104 liefert laut Messung tokenRights 1924 = 4+128+256+512+1024
+is( LoxBerry::Auth::_rights_granted(1924, $LoxBerry::Auth::PERM_SYSWS), 1, 'Sys-WS in 1924 enthalten' );
+is( LoxBerry::Auth::_rights_granted(1924, $LoxBerry::Auth::PERM_APP),   1, 'App in 1924 enthalten' );
+is( LoxBerry::Auth::_rights_granted(4,    $LoxBerry::Auth::PERM_SYSWS), 0, 'Sys-WS fehlt im reinen App-Token' );
+is( LoxBerry::Auth::_rights_granted(1924, 0x104),                       1, 'kombiniertes Bitmuster' );
+
+# --- Konstanten ------------------------------------------------------------
+is( $LoxBerry::Auth::DEFAULT_PERM,      0x104,        'Standard-Permission App+Sys-WS' );
+is( $LoxBerry::Auth::REFRESH_THRESHOLD, 7*86400,      'Erneuerungsschwelle 7 Tage' );
+is( $LoxBerry::Auth::MIN_FIRMWARE,      '11.2.10.22', 'Firmware-Floor' );
+
+done_testing();

--- a/libs/perllib/t/auth_store.t
+++ b/libs/perllib/t/auth_store.t
@@ -1,0 +1,140 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use File::Spec;
+use File::Temp qw( tempdir );
+use JSON;
+
+use lib File::Spec->catdir( $FindBin::Bin, '..' );
+use LoxBerry::Auth;
+
+my $dir = tempdir( CLEANUP => 1 );
+$LoxBerry::Auth::store_file = "$dir/tokens.json";
+
+sub slurp {
+	my ($file) = @_;
+	open( my $fh, '<', $file ) or die "cannot read $file: $!";
+	local $/;
+	my $content = <$fh>;
+	close($fh);
+	return $content;
+}
+
+is( LoxBerry::Auth::_store_file(), "$dir/tokens.json", 'store_file folgt dem Testhaken' );
+
+# --- Lesen ohne Datei ------------------------------------------------------
+my $empty = LoxBerry::Auth::_store_read();
+is_deeply( $empty, {}, 'fehlende Datei liefert leeren Hashref' );
+ok( ! -e "$dir/tokens.json", 'Lesen legt die Datei nicht an' );
+is( LoxBerry::Auth::_store_get_token('AB:CD:EF:01:02:03', 'loxberry'), undef,
+    'get_token auf leerem Bestand ist undef' );
+
+# --- Schreiben -------------------------------------------------------------
+my %msmeta = (
+	msnr          => 1,
+	name          => 'Miniserver',
+	is_lbsystem   => JSON::true,
+	lbsystem_user => 'loxberry',
+	firmware      => '17.1.7.3',
+	checked       => 556606212,
+);
+my %tok = (
+	token      => 'abc123',
+	validUntil => 564559554,
+	rights     => 1924,
+	perm       => 260,
+	acquired   => 556606212,
+	info       => 'LoxBerry testhost',
+);
+is( LoxBerry::Auth::_store_put_token('AB:CD:EF:01:02:03', 'loxberry', \%msmeta, \%tok), 1,
+    'erstes put schreibt' );
+ok( -e "$dir/tokens.json", 'Datei wurde angelegt' );
+
+my $mode = (stat("$dir/tokens.json"))[2] & 07777;
+is( $mode, 0600, 'Datei hat Rechte 0600' );
+
+my $got = LoxBerry::Auth::_store_get_token('AB:CD:EF:01:02:03', 'loxberry');
+is( $got->{token},      'abc123',   'Token gelesen' );
+is( $got->{validUntil}, 564559554,  'validUntil gelesen' );
+is( $got->{rights},     1924,       'rights gelesen' );
+
+# Struktur wie in der Spec
+my $raw = JSON::from_json( slurp("$dir/tokens.json") );
+is( $raw->{'AB:CD:EF:01:02:03'}{name},          'Miniserver', 'Miniserver-Metadaten auf oberster Ebene' );
+is( $raw->{'AB:CD:EF:01:02:03'}{firmware},      '17.1.7.3',   'firmware gespeichert' );
+is( $raw->{'AB:CD:EF:01:02:03'}{lbsystem_user}, 'loxberry',   'lbsystem_user gespeichert' );
+ok( exists $raw->{'AB:CD:EF:01:02:03'}{users}{loxberry},      'Benutzer unter users' );
+ok( ! exists $raw->{'AB:CD:EF:01:02:03'}{users}{loxberry}{password}, 'kein Passwort im Bestand' );
+ok( ! exists $raw->{'AB:CD:EF:01:02:03'}{users}{loxberry}{key},      'kein Einmalschluessel im Bestand' );
+
+# --- Nur bei echter Aenderung schreiben ------------------------------------
+my $mtime_before = (stat("$dir/tokens.json"))[9];
+sleep 1;
+is( LoxBerry::Auth::_store_put_token('AB:CD:EF:01:02:03', 'loxberry', \%msmeta, \%tok), 0,
+    'unveraendertes put schreibt nicht' );
+is( (stat("$dir/tokens.json"))[9], $mtime_before, 'mtime unveraendert - die SD-Karte bleibt verschont' );
+
+my %tok2 = (%tok, token => 'def456');
+is( LoxBerry::Auth::_store_put_token('AB:CD:EF:01:02:03', 'loxberry', \%msmeta, \%tok2), 1,
+    'geaendertes put schreibt' );
+is( LoxBerry::Auth::_store_get_token('AB:CD:EF:01:02:03', 'loxberry')->{token}, 'def456',
+    'neuer Token gelesen' );
+
+# --- Zweiter Benutzer, zweiter Miniserver ----------------------------------
+LoxBerry::Auth::_store_put_token('AB:CD:EF:01:02:03', 'sortmgr', \%msmeta, \%tok);
+LoxBerry::Auth::_store_put_token('AB:CD:EF:01:02:04', 'loxberry',
+	{ msnr => 2, name => 'MS2', is_lbsystem => JSON::false, firmware => '15.0.0.1', checked => 1 },
+	\%tok );
+is( LoxBerry::Auth::_store_get_token('AB:CD:EF:01:02:03', 'sortmgr')->{token},  'abc123', 'zweiter Benutzer' );
+is( LoxBerry::Auth::_store_get_token('AB:CD:EF:01:02:03', 'loxberry')->{token}, 'def456', 'erster Benutzer unberuehrt' );
+is( LoxBerry::Auth::_store_get_token('AB:CD:EF:01:02:04', 'loxberry')->{token}, 'abc123', 'zweiter Miniserver' );
+
+# --- Loeschen --------------------------------------------------------------
+is( LoxBerry::Auth::_store_del_token('AB:CD:EF:01:02:03', 'sortmgr'), 1, 'del schreibt' );
+is( LoxBerry::Auth::_store_get_token('AB:CD:EF:01:02:03', 'sortmgr'), undef, 'Eintrag ist weg' );
+is( LoxBerry::Auth::_store_del_token('AB:CD:EF:01:02:03', 'sortmgr'), 0, 'zweites del schreibt nicht' );
+
+# --- _store_update sieht den gesamten Bestand ------------------------------
+my $seen;
+LoxBerry::Auth::_store_update( sub {
+	my ($data) = @_;
+	$seen = [ sort keys %$data ];
+	return;
+} );
+is_deeply( $seen, [ 'AB:CD:EF:01:02:03', 'AB:CD:EF:01:02:04' ], 'update sieht beide Miniserver' );
+
+# --- Kaputte Datei bringt nichts zum Absturz -------------------------------
+open( my $fh, '>', "$dir/tokens.json" ) or die;
+print $fh "{ das ist kein json";
+close($fh);
+is_deeply( LoxBerry::Auth::_store_read(), {}, 'unlesbare Datei liefert leeren Hashref' );
+
+# --- Prozess-Cache ---------------------------------------------------------
+LoxBerry::Auth::_cache_clear();
+LoxBerry::Auth::_store_put_token('AA:BB:CC:DD:EE:FF', 'cacheuser',
+	{ msnr => 1 }, { token => 'cached1', validUntil => 5, rights => 1924 } );
+
+# Datei unter dem Prozess wegziehen - der Cache muss weiter antworten
+unlink("$dir/tokens.json");
+is( LoxBerry::Auth::_store_get_token('AA:BB:CC:DD:EE:FF', 'cacheuser')->{token}, 'cached1',
+    'get_token bedient sich aus dem Prozess-Cache, ohne die Datei zu lesen' );
+
+# nach _cache_clear ist die Information weg, weil auch die Datei weg ist
+LoxBerry::Auth::_cache_clear();
+is( LoxBerry::Auth::_store_get_token('AA:BB:CC:DD:EE:FF', 'cacheuser'), undef,
+    'ohne Cache und ohne Datei ist nichts mehr da' );
+
+# ein Schreibvorgang aktualisiert den Cache mit
+LoxBerry::Auth::_store_put_token('AA:BB:CC:DD:EE:FF', 'cacheuser',
+	{ msnr => 1 }, { token => 'cached2', validUntil => 5, rights => 1924 } );
+is( LoxBerry::Auth::_store_get_token('AA:BB:CC:DD:EE:FF', 'cacheuser')->{token}, 'cached2',
+    'put aktualisiert den Cache' );
+
+# und ein Loeschen raeumt ihn
+LoxBerry::Auth::_store_del_token('AA:BB:CC:DD:EE:FF', 'cacheuser');
+is( LoxBerry::Auth::_store_get_token('AA:BB:CC:DD:EE:FF', 'cacheuser'), undef,
+    'del raeumt den Cache mit' );
+
+done_testing();

--- a/libs/phplib/loxberry_auth.php
+++ b/libs/phplib/loxberry_auth.php
@@ -1,0 +1,776 @@
+<?php
+// loxberry_auth.php - token authentication at the Loxone Miniserver.
+// Port of libs/perllib/LoxBerry/Auth.pm - same method names, same array keys.
+// PHP 7.4 compatible (that is the version on the target systems).
+
+require_once "loxberry_system.php";
+
+class LBAuth
+{
+	public static $VERSION = "4.0.0.1";
+	public static $DEBUG = 0;
+
+	// Permission bits of the Miniserver token API
+	const PERM_ADMIN = 0x01;
+	const PERM_WEB   = 0x02;
+	const PERM_APP   = 0x04;
+	const PERM_SYSWS = 0x100;
+
+	// App + Sys-WS: ~3 months lifetime, includes the right to reboot
+	public static $DEFAULT_PERM = 0x104;
+	// Renew as soon as less than this many seconds are left
+	public static $REFRESH_THRESHOLD = 604800;
+	public static $TIMEOUT = 10;
+	// Below this firmware the token endpoints need application layer encryption
+	public static $MIN_FIRMWARE = "11.2.10.22";
+
+	// Test hooks
+	public static $store_file = null;
+	public static $transport  = null;
+
+	private static function dbg($msg)
+	{
+		if (self::$DEBUG) { error_log("loxberry_auth: " . $msg); }
+	}
+
+	####################################################
+	# Pure helpers - no I/O, no state
+	####################################################
+
+	// An empty hashAlg means SHA1 (Miniservers before the field existed)
+	public static function _norm_alg($alg)
+	{
+		$alg = ($alg === null) ? '' : strtoupper($alg);
+		$alg = preg_replace('/[^A-Z0-9]/', '', $alg);
+		if ($alg === '' || $alg === 'SHA1') { return 'SHA1'; }
+		if ($alg === 'SHA256') { return 'SHA256'; }
+		return null;
+	}
+
+	public static function _hash_hex($alg, $data)
+	{
+		return hash($alg === 'SHA256' ? 'sha256' : 'sha1', $data);
+	}
+
+	// The key from getkey2 is hex encoded and used as raw bytes
+	public static function _hmac_hex($alg, $data, $keyhex)
+	{
+		return hash_hmac($alg === 'SHA256' ? 'sha256' : 'sha1', $data, hex2bin($keyhex));
+	}
+
+	// The Miniserver expects the password hash in uppercase
+	public static function _pw_hash($password, $salt, $alg)
+	{
+		return strtoupper(self::_hash_hex($alg, $password . ':' . $salt));
+	}
+
+	public static function _auth_hash($user, $pwhash, $keyhex, $alg)
+	{
+		return self::_hmac_hex($alg, $user . ':' . $pwhash, $keyhex);
+	}
+
+	public static function _token_hash($token, $keyhex, $alg)
+	{
+		return self::_hmac_hex($alg, $token, $keyhex);
+	}
+
+	// jdev/cfg/api returns its value as a STRING using single quotes - that is
+	// not valid JSON and must not be fed to json_decode.
+	public static function _parse_api_value($value)
+	{
+		if ($value === null || $value === '') { return null; }
+		$out = array();
+		if (preg_match_all("/'([^']+)'\\s*:\\s*(?:'([^']*)'|([^,}\\s]+))/", $value, $m, PREG_SET_ORDER)) {
+			foreach ($m as $one) {
+				$out[$one[1]] = ($one[2] !== '') ? $one[2] : (isset($one[3]) ? $one[3] : $one[2]);
+			}
+		}
+		return count($out) ? $out : null;
+	}
+
+	public static function _fw_supported($fw)
+	{
+		if ($fw === null || $fw === '') { return 0; }
+		$is  = explode('.', $fw);
+		$min = explode('.', self::$MIN_FIRMWARE);
+		for ($i = 0; $i < 4; $i++) {
+			$a = isset($is[$i])  ? intval($is[$i])  : 0;
+			$b = isset($min[$i]) ? intval($min[$i]) : 0;
+			if ($a > $b) { return 1; }
+			if ($a < $b) { return 0; }
+		}
+		return 1;
+	}
+
+	// tokenRights is a bitmask; perm 0x104 was measured to return 1924
+	public static function _rights_granted($rights, $bit)
+	{
+		if ($rights === null || $bit === null) { return 0; }
+		return ((intval($rights) & intval($bit)) == intval($bit)) ? 1 : 0;
+	}
+
+	####################################################
+	# Token store - data/system/tokens.json, 0600, owner loxberry
+	####################################################
+
+	public static function _store_file()
+	{
+		if (self::$store_file) { return self::$store_file; }
+		global $lbsdatadir;
+		if (!empty($lbsdatadir)) { return $lbsdatadir . "/tokens.json"; }
+		return null;
+	}
+
+	private static function _ksort_deep(&$a)
+	{
+		if (!is_array($a)) { return; }
+		ksort($a);
+		foreach ($a as $k => $v) {
+			if (is_array($v)) { self::_ksort_deep($a[$k]); }
+		}
+	}
+
+	private static function _store_decode($content)
+	{
+		if ($content === null || trim($content) === '') { return array(); }
+		$data = json_decode($content, true);
+		if (!is_array($data)) {
+			self::dbg("tokens.json is not readable JSON - starting empty");
+			return array();
+		}
+		return $data;
+	}
+
+	private static function _store_encode($data)
+	{
+		$copy = $data;
+		self::_ksort_deep($copy);
+		return json_encode($copy, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+	}
+
+	// Read the full store under a shared lock. A missing file is an empty
+	// store and is NOT created here.
+	public static function _store_read()
+	{
+		$file = self::_store_file();
+		if (!$file || !file_exists($file)) { return array(); }
+		$fh = @fopen($file, 'r');
+		if (!$fh) { return array(); }
+		@flock($fh, LOCK_SH);
+		$content = stream_get_contents($fh);
+		@flock($fh, LOCK_UN);
+		fclose($fh);
+		return self::_store_decode($content);
+	}
+
+	// Read-modify-write under ONE exclusive lock. $cb must take the store BY
+	// REFERENCE: function (&$data) { ... }
+	// Returns 1 = written, 0 = unchanged, null = error.
+	public static function _store_update($cb)
+	{
+		$file = self::_store_file();
+		if (!$file) { self::dbg("no token store path available"); return null; }
+
+		$fh = @fopen($file, 'c+');
+		if (!$fh) { self::dbg("cannot open $file"); return null; }
+		if (!flock($fh, LOCK_EX)) { fclose($fh); return null; }
+
+		$content = stream_get_contents($fh);
+		$data    = self::_store_decode($content);
+		$before  = self::_store_encode($data);
+
+		$cb($data);
+
+		$after = self::_store_encode($data);
+		if ($after === $before && trim($content) !== '') {
+			@flock($fh, LOCK_UN);
+			fclose($fh);
+			return 0;
+		}
+
+		rewind($fh);
+		ftruncate($fh, 0);
+		fwrite($fh, $after);
+		fflush($fh);
+		@flock($fh, LOCK_UN);
+		fclose($fh);
+
+		@chmod($file, 0600);
+		@chown($file, 'loxberry');
+		return 1;
+	}
+
+	// Process cache: the token lives in the process, the file is pure
+	// persistence across restarts. The single 401 retry in request() covers
+	// the case that another process changed the file behind our back.
+	private static $tokencache = array();
+
+	public static function _cache_clear()
+	{
+		self::$tokencache = array();
+		return 1;
+	}
+
+	public static function _store_get_token($serial, $user)
+	{
+		if (!$serial || !$user) { return null; }
+		$ck = "$serial|$user";
+		if (array_key_exists($ck, self::$tokencache)) { return self::$tokencache[$ck]; }
+
+		$data = self::_store_read();
+		if (!isset($data[$serial]['users'][$user])) { return null; }
+		self::$tokencache[$ck] = $data[$serial]['users'][$user];
+		return self::$tokencache[$ck];
+	}
+
+	public static function _store_put_token($serial, $user, $msmeta, $tokendata)
+	{
+		if (!$serial || !$user) { return null; }
+		self::$tokencache["$serial|$user"] = $tokendata;
+		return self::_store_update(function (&$data) use ($serial, $user, $msmeta, $tokendata) {
+			if (!isset($data[$serial])) { $data[$serial] = array(); }
+			foreach ($msmeta as $k => $v) { $data[$serial][$k] = $v; }
+			if (!isset($data[$serial]['users'])) { $data[$serial]['users'] = array(); }
+			$data[$serial]['users'][$user] = $tokendata;
+		});
+	}
+
+	public static function _store_del_token($serial, $user)
+	{
+		if (!$serial || !$user) { return null; }
+		unset(self::$tokencache["$serial|$user"]);
+		return self::_store_update(function (&$data) use ($serial, $user) {
+			if (isset($data[$serial]['users'][$user])) {
+				unset($data[$serial]['users'][$user]);
+			}
+		});
+	}
+
+	####################################################
+	# Result objects
+	####################################################
+
+	public static function _err($code, $message)
+	{
+		self::dbg("$code - $message");
+		return array('ok' => 0, 'error' => $code, 'message' => $message);
+	}
+
+	####################################################
+	# Miniserver resolution
+	####################################################
+
+	public static function _ms_baseurl($msc)
+	{
+		if (!$msc) { return null; }
+		$transport = !empty($msc['Transport']) ? $msc['Transport'] : 'http';
+		$port = ($transport == 'https') ? $msc['PortHttps'] : $msc['Port'];
+		if (!$port) { $port = ($transport == 'https') ? 443 : 80; }
+		$ip = $msc['IPAddress'];
+		if (strpos($ip, ':') !== false) { $ip = '[' . $ip . ']'; }
+		return "$transport://$ip:$port";
+	}
+
+	// Accepts a Miniserver number or a serial. A serial is resolved through the
+	// token store. With a user but without a password the password stays null
+	// on purpose - the password from general.json belongs to that user only.
+	public static function _resolve_ms($ms, $opts = array())
+	{
+		if ($ms === null || $ms === '') { return self::_err('msnotfound', 'No Miniserver given'); }
+
+		$serial = null;
+		$msnr   = null;
+		if (preg_match('/^\d+$/', (string)$ms)) {
+			$msnr = intval($ms);
+		} else {
+			$serial = strtoupper($ms);
+			$data = self::_store_read();
+			if (isset($data[$serial]['msnr'])) { $msnr = $data[$serial]['msnr']; }
+			if ($msnr === null) {
+				return self::_err('msnotfound',
+					"Serial $ms is unknown - fetch a token for this Miniserver first");
+			}
+		}
+
+		$miniservers = LBSystem::get_miniservers();
+		if (!isset($miniservers[$msnr])) {
+			return self::_err('msnotfound', "Miniserver $ms is not configured");
+		}
+		$msc = $miniservers[$msnr];
+
+		$user = isset($opts['user']) ? $opts['user'] : $msc['Admin_RAW'];
+		if (isset($opts['password'])) {
+			$password = $opts['password'];
+		} else {
+			$password = isset($opts['user']) ? null : $msc['Pass_RAW'];
+		}
+
+		return array(
+			'ok'            => 1,
+			'msnr'          => $msnr,
+			'name'          => $msc['Name'],
+			'baseurl'       => self::_ms_baseurl($msc),
+			'user'          => $user,
+			'password'      => $password,
+			'serial'        => $serial,
+			'is_lbsystem'   => 1,
+			'lbsystem_user' => $msc['Admin_RAW'],
+		);
+	}
+
+	####################################################
+	# general.json: Authmethod (read only - never written by this lib)
+	####################################################
+
+	public static function auth_method($ms)
+	{
+		if ($ms === null || $ms === '') { return 'basicauth'; }
+
+		$msnr = $ms;
+		if (!preg_match('/^\d+$/', (string)$ms)) {
+			$data = self::_store_read();
+			$serial = strtoupper($ms);
+			if (!isset($data[$serial]['msnr'])) { return 'basicauth'; }
+			$msnr = $data[$serial]['msnr'];
+		}
+
+		global $lbsconfigdir;
+		$raw = @file_get_contents("$lbsconfigdir/general.json");
+		if ($raw === false) { return 'basicauth'; }
+		$cfg = json_decode($raw, true);
+		if (!is_array($cfg)) { return 'basicauth'; }
+
+		if (isset($cfg['Miniserver'][$msnr]['Authmethod'])
+		    && strtolower($cfg['Miniserver'][$msnr]['Authmethod']) === 'token') {
+			return 'token';
+		}
+		return 'basicauth';
+	}
+
+	####################################################
+	# HTTP transport
+	# Verified on Miniserver 17.1.7.3: jdev/cfg/api and jdev/sys/getkey2 answer
+	# without any authentication. Only killtoken needs Basic Auth.
+	####################################################
+
+	public static function _http_get($url, $opts = array())
+	{
+		$ch = curl_init($url);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_HEADER, false);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+		curl_setopt($ch, CURLOPT_TIMEOUT, isset($opts['timeout']) ? $opts['timeout'] : self::$TIMEOUT);
+		if (isset($opts['basicauth_user'])) {
+			curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+			curl_setopt($ch, CURLOPT_USERPWD, $opts['basicauth_user'] . ':'
+			            . (isset($opts['basicauth_password']) ? $opts['basicauth_password'] : ''));
+		}
+		$body = curl_exec($ch);
+		$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+		$err  = curl_error($ch);
+		curl_close($ch);
+		// no connection at all -> code 0
+		if ($body === false || !$code) { return array(null, null, $err ? $err : 'no connection'); }
+		return array(intval($code), $body, strval($code));
+	}
+
+	public static function _call($url, $opts = array())
+	{
+		self::dbg("GET $url");
+		$t = self::$transport ? self::$transport : array('LBAuth', '_http_get');
+		return call_user_func($t, $url, $opts);
+	}
+
+	// The LL envelope. value is an array for most endpoints and a string for
+	// jdev/cfg/api. A non-JSON body (the Miniserver answers 401 in HTML) is null.
+	public static function _ll_value($body)
+	{
+		if ($body === null || trim($body) === '') { return null; }
+		$j = json_decode($body, true);
+		if (!is_array($j) || !isset($j['LL']) || !is_array($j['LL'])) { return null; }
+		return isset($j['LL']['value']) ? $j['LL']['value'] : null;
+	}
+
+	// The LL envelope carries its OWN status code, and the Miniserver does not
+	// always mirror it into the HTTP status: refreshjwt answers HTTP 200 with
+	// LL.code 401 when the token signature is not accepted. Measured on 17.1.7.3.
+	// The field is spelled "Code" by some endpoints (jdev/cfg/api) and "code" by
+	// others (jdev/sys/*), so both are read.
+	public static function _ll_code($body)
+	{
+		if ($body === null || trim($body) === '') { return null; }
+		$j = json_decode($body, true);
+		if (!is_array($j) || !isset($j['LL']) || !is_array($j['LL'])) { return null; }
+		$c = isset($j['LL']['code']) ? $j['LL']['code'] : (isset($j['LL']['Code']) ? $j['LL']['Code'] : null);
+		if ($c === null || !preg_match('/^\d+$/', (string)$c)) { return null; }
+		return intval($c);
+	}
+
+	// The code that really decides: an HTTP 200 carrying a different LL code is
+	// a failure, not a success.
+	public static function _effective_code($code, $body)
+	{
+		if ($code === null || $code != 200) { return $code; }
+		$ll = self::_ll_code($body);
+		if ($ll !== null && $ll != 200) { return $ll; }
+		return $code;
+	}
+
+	// Stable per host and user, so the Miniserver does not collect a new client
+	// entry on every call. Derived, never persisted.
+	public static function _client_uuid($user)
+	{
+		$h = hash('sha256', lbhostname() . '|' . $user . '|loxberry-auth');
+		return substr($h,0,8) . '-' . substr($h,8,4) . '-' . substr($h,12,4) . '-'
+		     . substr($h,16,4) . '-' . substr($h,20,12);
+	}
+
+	####################################################
+	# Miniserver identity: serial + firmware in one call
+	####################################################
+
+	public static function _ms_api($res, $opts = array())
+	{
+		list($code, $body) = self::_call($res['baseurl'] . '/jdev/cfg/api', $opts);
+		if ($code === null) { return self::_err('unreachable', $res['baseurl'] . ' did not answer'); }
+		$code = self::_effective_code($code, $body);
+		if ($code != 200)   { return self::_err('httperror', "jdev/cfg/api returned $code"); }
+
+		$api = self::_parse_api_value(self::_ll_value($body));
+		if (!$api) { return self::_err('parseerror', 'jdev/cfg/api could not be parsed'); }
+		if (empty($api['snr'])) { return self::_err('parseerror', 'jdev/cfg/api has no serial'); }
+
+		return array('ok' => 1, 'serial' => strtoupper($api['snr']),
+		             'firmware' => isset($api['version']) ? $api['version'] : '');
+	}
+
+	public static function _getkey2($res, $user, $opts = array())
+	{
+		$url = $res['baseurl'] . '/jdev/sys/getkey2/' . rawurlencode($user);
+		list($code, $body) = self::_call($url, $opts);
+		if ($code === null) { return self::_err('unreachable', $res['baseurl'] . ' did not answer'); }
+		$code = self::_effective_code($code, $body);
+		if ($code == 401)   { return self::_err('badcredentials', "getkey2 returned $code for user $user"); }
+		if ($code != 200)   { return self::_err('httperror', "getkey2 returned $code"); }
+
+		$v = self::_ll_value($body);
+		if (!is_array($v)) { return self::_err('parseerror', 'getkey2 could not be parsed'); }
+		$alg = self::_norm_alg(isset($v['hashAlg']) ? $v['hashAlg'] : null);
+		if (!$alg) { return self::_err('parseerror', 'getkey2 returned an unknown hashAlg'); }
+		return array('ok' => 1, 'key' => $v['key'], 'salt' => $v['salt'], 'alg' => $alg);
+	}
+
+	// The serial of a Miniserver number, as far as an earlier run persisted it.
+	// Looking it up here keeps get_token free of HTTP when a token is cached.
+	public static function _serial_from_store($msnr)
+	{
+		$data = self::_store_read();
+		foreach ($data as $s => $entry) {
+			if (isset($entry['msnr']) && $entry['msnr'] == $msnr) {
+				return array($s, isset($entry['firmware']) ? $entry['firmware'] : null);
+			}
+		}
+		return array(null, null);
+	}
+
+	// Like _resolve_ms, but an unknown serial makes every configured Miniserver
+	// be asked for its own serial. That is the only way a serial enters the store.
+	public static function _resolve_ms_probing($ms, $opts = array())
+	{
+		$res = self::_resolve_ms($ms, $opts);
+		if ($res['ok']) { return $res; }
+		if (preg_match('/^\d+$/', (string)$ms)) { return $res; }
+
+		$want = strtoupper($ms);
+		$miniservers = LBSystem::get_miniservers();
+		$keys = array_keys($miniservers);
+		sort($keys);
+		foreach ($keys as $msnr) {
+			$cand = self::_resolve_ms($msnr, $opts);
+			if (!$cand['ok']) { continue; }
+			$api = self::_ms_api($cand, $opts);
+			if (!$api['ok'] || $api['serial'] !== $want) { continue; }
+			$cand['serial']   = $want;
+			$cand['firmware'] = $api['firmware'];
+			return $cand;
+		}
+		return self::_err('msnotfound', "No configured Miniserver has serial $ms");
+	}
+
+	####################################################
+	# get_token
+	####################################################
+
+	public static function get_token($ms, $opts = array())
+	{
+		$res = self::_resolve_ms_probing($ms, $opts);
+		if (!$res['ok']) { return $res; }
+
+		$user = $res['user'];
+		if (!$user) { return self::_err('nocredentials', "No user for Miniserver $ms"); }
+
+		$perm = isset($opts['perm']) ? intval($opts['perm']) : self::$DEFAULT_PERM;
+
+		// The serial is stable and may come from the store - that is what keeps
+		// a cached token completely free of HTTP.
+		$serial   = $res['serial'];
+		$firmware = isset($res['firmware']) ? $res['firmware'] : null;
+		if (!$serial) {
+			list($s, $f) = self::_serial_from_store($res['msnr']);
+			$serial = $s;
+			if (!$firmware) { $firmware = $f; }
+		}
+
+		if (empty($opts['force']) && $serial) {
+			$have = self::_store_get_token($serial, $user);
+			if ($have && !empty($have['token']) && self::_rights_granted($have['rights'], $perm)) {
+				return array('ok' => 1, 'token' => $have['token'], 'validUntil' => $have['validUntil'],
+				             'rights' => $have['rights'], 'perm' => $have['perm'], 'user' => $user,
+				             'serial' => $serial, 'firmware' => $firmware, 'msnr' => $res['msnr']);
+			}
+		}
+
+		// Without a password nothing can be fetched - check that before
+		// bothering the Miniserver with a single request.
+		$password = $res['password'];
+		if ($password === null || $password === '') {
+			return self::_err('nocredentials', "No password available for user $user");
+		}
+
+		// From here on a token is really fetched. Unlike the serial the
+		// firmware changes with every Miniserver update, so it is never taken
+		// from the store.
+		if (!isset($res['firmware'])) {
+			$api = self::_ms_api($res, $opts);
+			if (!$api['ok']) { return $api; }
+			$serial   = $api['serial'];
+			$firmware = $api['firmware'];
+		}
+
+		if (!self::_fw_supported($firmware)) {
+			return self::_err('fwtooold', "Miniserver firmware $firmware is below "
+			       . self::$MIN_FIRMWARE . " - tokens would need application encryption");
+		}
+
+		$k = self::_getkey2($res, $user, $opts);
+		if (!$k['ok']) { return $k; }
+
+		$pwhash   = self::_pw_hash($password, $k['salt'], $k['alg']);
+		$authhash = self::_auth_hash($user, $pwhash, $k['key'], $k['alg']);
+		$info     = isset($opts['info']) ? $opts['info'] : 'LoxBerry ' . lbhostname();
+
+		$url = $res['baseurl'] . '/jdev/sys/gettoken/' . $authhash . '/' . rawurlencode($user)
+		     . '/' . $perm . '/' . self::_client_uuid($user) . '/' . rawurlencode($info);
+
+		list($code, $body) = self::_call($url, $opts);
+		if ($code === null) { return self::_err('unreachable', $res['baseurl'] . ' did not answer'); }
+		$code = self::_effective_code($code, $body);
+		// A wrong user or password shows up HERE, not at getkey2
+		if ($code == 401) { return self::_err('badcredentials', "gettoken returned 401 for user $user"); }
+		if ($code != 200) { return self::_err('httperror', "gettoken returned $code"); }
+
+		$v = self::_ll_value($body);
+		if (!is_array($v) || empty($v['token'])) { return self::_err('parseerror', 'gettoken could not be parsed'); }
+
+		if (!self::_rights_granted($v['tokenRights'], $perm)) {
+			return self::_err('missingright', sprintf(
+				"Miniserver granted rights %s, which does not include the requested permission %d (0x%x)",
+				$v['tokenRights'], $perm, $perm));
+		}
+
+		$tokendata = array(
+			'token' => $v['token'], 'validUntil' => $v['validUntil'], 'rights' => $v['tokenRights'],
+			'perm' => $perm, 'acquired' => epoch2lox(), 'info' => $info,
+		);
+		self::_store_put_token($serial, $user, array(
+			'msnr' => $res['msnr'], 'name' => $res['name'], 'is_lbsystem' => $res['is_lbsystem'],
+			'lbsystem_user' => $res['lbsystem_user'], 'firmware' => $firmware, 'checked' => epoch2lox(),
+		), $tokendata);
+
+		return array_merge($tokendata, array('ok' => 1, 'user' => $user, 'serial' => $serial,
+		                                     'firmware' => $firmware, 'msnr' => $res['msnr']));
+	}
+
+	####################################################
+	# token_info / refresh_token / kill_token / request
+	####################################################
+
+	public static function token_info($ms, $opts = array())
+	{
+		$res = self::_resolve_ms_probing($ms, $opts);
+		if (!$res['ok']) { return $res; }
+
+		$serial = $res['serial'];
+		$data   = self::_store_read();
+		if (!$serial) {
+			foreach ($data as $s => $entry) {
+				if (isset($entry['msnr']) && $entry['msnr'] == $res['msnr']) { $serial = $s; break; }
+			}
+		}
+		if (!$serial) { return self::_err('notoken', "No token stored for Miniserver $ms"); }
+
+		if (empty($data[$serial]['users'][$res['user']]['token'])) {
+			return self::_err('notoken', "No token stored for user " . $res['user']);
+		}
+		$have = $data[$serial]['users'][$res['user']];
+
+		return array(
+			'ok' => 1, 'token' => $have['token'], 'validUntil' => $have['validUntil'],
+			'rights' => $have['rights'], 'perm' => isset($have['perm']) ? $have['perm'] : null,
+			'info' => isset($have['info']) ? $have['info'] : null,
+			'user' => $res['user'], 'serial' => $serial, 'msnr' => $res['msnr'],
+			'firmware' => isset($data[$serial]['firmware']) ? $data[$serial]['firmware'] : null,
+			'expires_in' => intval($have['validUntil']) - epoch2lox(),
+		);
+	}
+
+	// refreshjwt works with token authentication only - no password involved.
+	// It answers with a JWT (eyJ0eXAi...) instead of the hex token.
+	public static function refresh_token($ms, $opts = array())
+	{
+		$have = self::token_info($ms, $opts);
+		if (!$have['ok']) { return $have; }
+		$res = self::_resolve_ms_probing($ms, $opts);
+		if (!$res['ok']) { return $res; }
+
+		$k = self::_getkey2($res, $have['user'], $opts);
+		if (!$k['ok']) { return $k; }
+		$hash = self::_token_hash($have['token'], $k['key'], $k['alg']);
+
+		// The path carries the token HASH, autht the PLAIN token. Measured on
+		// 17.1.7.3: hashing both consumes the one-time key twice and the
+		// Miniserver answers HTTP 200 with LL.code 401.
+		$url = $res['baseurl'] . '/jdev/sys/refreshjwt/' . $hash . '/' . rawurlencode($have['user'])
+		     . '?autht=' . rawurlencode($have['token']) . '&user=' . rawurlencode($have['user']);
+
+		list($code, $body) = self::_call($url, $opts);
+		if ($code === null) { return self::_err('unreachable', $res['baseurl'] . ' did not answer'); }
+		$code = self::_effective_code($code, $body);
+		if ($code == 401) { return self::_err('revoked', 'refreshjwt returned 401 - the token was not accepted'); }
+		if ($code != 200) { return self::_err('httperror', "refreshjwt returned $code"); }
+
+		$v = self::_ll_value($body);
+		if (!is_array($v) || empty($v['token'])) { return self::_err('parseerror', 'refreshjwt could not be parsed'); }
+
+		$tokendata = array(
+			'token' => $v['token'], 'validUntil' => $v['validUntil'],
+			'rights' => isset($v['tokenRights']) ? $v['tokenRights'] : $have['rights'],
+			'perm' => $have['perm'], 'acquired' => epoch2lox(), 'info' => $have['info'],
+		);
+		self::_store_put_token($have['serial'], $have['user'],
+			array('msnr' => $res['msnr'], 'checked' => epoch2lox()), $tokendata);
+
+		return array_merge($tokendata, array('ok' => 1, 'user' => $have['user'],
+			'serial' => $have['serial'], 'firmware' => $have['firmware'], 'msnr' => $res['msnr']));
+	}
+
+	// Revoking needs the password: killtoken was measured to work with Basic
+	// Auth only, not with token authentication.
+	public static function kill_token($ms, $opts = array())
+	{
+		$have = self::token_info($ms, $opts);
+		if (!$have['ok']) { return $have; }
+		$res = self::_resolve_ms_probing($ms, $opts);
+		if (!$res['ok']) { return $res; }
+		if ($res['password'] === null || $res['password'] === '') {
+			return self::_err('nopassword', "kill_token needs the password of user " . $have['user']);
+		}
+
+		$k = self::_getkey2($res, $have['user'], $opts);
+		if (!$k['ok']) { return $k; }
+		$hash = self::_token_hash($have['token'], $k['key'], $k['alg']);
+
+		$url = $res['baseurl'] . '/jdev/sys/killtoken/' . $hash . '/' . rawurlencode($have['user']);
+		$callopts = array_merge($opts, array(
+			'basicauth_user' => $have['user'], 'basicauth_password' => $res['password']));
+
+		list($code, $body) = self::_call($url, $callopts);
+		if ($code === null) { return self::_err('unreachable', $res['baseurl'] . ' did not answer'); }
+		$code = self::_effective_code($code, $body);
+		if ($code == 401) { return self::_err('badcredentials', 'killtoken returned 401'); }
+		if ($code != 200) { return self::_err('httperror', "killtoken returned $code"); }
+
+		self::_store_del_token($have['serial'], $have['user']);
+		return array('ok' => 1, 'user' => $have['user'], 'serial' => $have['serial']);
+	}
+
+	private static function _sign_url($baseurl, $command, $token, $user, $res, $opts)
+	{
+		$k = self::_getkey2($res, $user, $opts);
+		if (!$k['ok']) { return array(null, $k); }
+		$hash = self::_token_hash($token, $k['key'], $k['alg']);
+		$sep = (strpos($command, '?') !== false) ? '&' : '?';
+		return array($baseurl . $command . $sep . 'autht=' . $hash . '&user=' . rawurlencode($user), null);
+	}
+
+	// Returns array($content, $info) - same keys as mshttp_call2, plus errcode.
+	public static function request($ms, $command, $opts = array())
+	{
+		$info = array('code' => null, 'status' => null, 'error' => 1, 'message' => '', 'errcode' => null);
+
+		$tok = self::get_token($ms, $opts);
+		if (!$tok['ok']) {
+			$info['errcode'] = $tok['error']; $info['message'] = $tok['message'];
+			return array(null, $info);
+		}
+
+		$left = intval($tok['validUntil']) - epoch2lox();
+		if ($left <= 0) {
+			$tok = self::get_token($ms, array_merge($opts, array('force' => 1)));
+		} elseif ($left < self::$REFRESH_THRESHOLD) {
+			$r = self::refresh_token($ms, $opts);
+			if ($r['ok']) { $tok = $r; }
+		}
+		if (!$tok['ok']) {
+			$info['errcode'] = $tok['error']; $info['message'] = $tok['message'];
+			return array(null, $info);
+		}
+
+		$res = self::_resolve_ms_probing($ms, $opts);
+		if (!$res['ok']) {
+			$info['errcode'] = $res['error']; $info['message'] = $res['message'];
+			return array(null, $info);
+		}
+
+		for ($attempt = 1; $attempt <= 2; $attempt++) {
+			list($url, $urlerr) = self::_sign_url($res['baseurl'], $command, $tok['token'], $tok['user'], $res, $opts);
+			if (!$url) {
+				$info['errcode'] = $urlerr['error']; $info['message'] = $urlerr['message'];
+				return array(null, $info);
+			}
+
+			list($code, $body, $status) = self::_call($url, $opts);
+			if ($code === null) {
+				$info['errcode'] = 'unreachable';
+				$info['message'] = $res['baseurl'] . ' did not answer';
+				return array(null, $info);
+			}
+			$code = self::_effective_code($code, $body);
+			$info['code'] = $code; $info['status'] = $status;
+
+			if ($code == 401) {
+				// The token may be gone on the Miniserver although validUntil
+				// still looks fine. Fetch a new one and retry ONCE.
+				if ($attempt == 1) {
+					$fresh = self::get_token($ms, array_merge($opts, array('force' => 1)));
+					if ($fresh['ok']) { $tok = $fresh; continue; }
+					$info['errcode'] = $fresh['error']; $info['message'] = $fresh['message'];
+					return array(null, $info);
+				}
+				$info['errcode'] = 'revoked';
+				$info['message'] = "$command returned 401 twice - the token was revoked";
+				return array(null, $info);
+			}
+
+			if ($code < 200 || $code >= 300) {
+				$info['errcode'] = 'httperror';
+				$info['message'] = "$command FAILED - Error $code";
+				return array(null, $info);
+			}
+
+			$info['error'] = 0; $info['message'] = 'Request ok';
+			return array($body, $info);
+		}
+	}
+}

--- a/libs/phplib/testing/libcompare.php
+++ b/libs/phplib/testing/libcompare.php
@@ -116,3 +116,64 @@ LBSystem::unlock(array('lockfile' => 'libcompare_test'));
 $rlock   = LBSystem::lock(array('lockfile' => 'libcompare_test', 'wait' => 0));
 $runlock = LBSystem::unlock(array('lockfile' => 'libcompare_test'));
 emit('lock_unlock', array('lock' => $rlock, 'unlock' => $runlock));
+
+/////////////////////////////////////////////
+// Auth (pure functions)
+/////////////////////////////////////////////
+set_include_path(get_include_path() . PATH_SEPARATOR . dirname(__DIR__));
+require_once dirname(__DIR__) . "/loxberry_auth.php";
+
+$auth_key  = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+$auth_apiv = "{'snr': 'AB:CD:EF:01:02:03', 'version':'17.1.7.3', 'hasEventSlots':true, "
+           . "'isInTrust':false, 'local':true,'certTLD':'com'}";
+
+$auth_algs = array();
+foreach (array('SHA256', 'sha-256', 'SHA1', '', 'MD5') as $a) { $auth_algs[] = LBAuth::_norm_alg($a); }
+emit('auth_norm_alg', $auth_algs);
+
+$auth_pw256 = LBAuth::_pw_hash('Test1234', '41B0A8F1', 'SHA256');
+$auth_pw1   = LBAuth::_pw_hash('Test1234', '41B0A8F1', 'SHA1');
+emit('auth_hashes', array(
+	'pw_sha256'    => $auth_pw256,
+	'pw_sha1'      => $auth_pw1,
+	'auth_sha256'  => LBAuth::_auth_hash('loxberry', $auth_pw256, $auth_key, 'SHA256'),
+	'auth_sha1'    => LBAuth::_auth_hash('loxberry', $auth_pw1, $auth_key, 'SHA1'),
+	'token_sha256' => LBAuth::_token_hash('a1b2c3d4e5f60718293a4b5c6d7e8f90', $auth_key, 'SHA256'),
+	'token_sha1'   => LBAuth::_token_hash('a1b2c3d4e5f60718293a4b5c6d7e8f90', $auth_key, 'SHA1'),
+));
+
+emit('auth_parse_api_value', LBAuth::_parse_api_value($auth_apiv));
+
+$auth_fw = array();
+foreach (array('17.1.7.3', '11.2.10.22', '11.2.10.21', '11.2.9.99', '12.0', '') as $f) {
+	$auth_fw[] = LBAuth::_fw_supported($f);
+}
+emit('auth_fw_supported', $auth_fw);
+
+emit('auth_rights_granted', array(
+	LBAuth::_rights_granted(1924, 0x100),
+	LBAuth::_rights_granted(1924, 0x04),
+	LBAuth::_rights_granted(4,    0x100),
+	LBAuth::_rights_granted(1924, 0x104),
+));
+
+emit('auth_ll_codes', array(
+	LBAuth::_ll_code('{"LL":{"value":{},"code":"401"}}'),
+	LBAuth::_ll_code('{"LL":{"value":"x","Code":"200"}}'),
+	LBAuth::_ll_code('<html>401</html>'),
+	LBAuth::_effective_code(200, '{"LL":{"value":{},"code":"401"}}'),
+	LBAuth::_effective_code(200, '{"LL":{"value":"x","Code":"200"}}'),
+	LBAuth::_effective_code(401, '<html>401</html>'),
+));
+
+emit('auth_constants', array(
+	'default_perm'      => LBAuth::$DEFAULT_PERM,
+	'refresh_threshold' => LBAuth::$REFRESH_THRESHOLD,
+	'min_firmware'      => LBAuth::$MIN_FIRMWARE,
+	'perm_app'          => LBAuth::PERM_APP,
+	'perm_sysws'        => LBAuth::PERM_SYSWS,
+));
+
+$auth_ms = LBSystem::get_miniservers();
+emit('auth_ms_baseurl', isset($auth_ms[1]) ? LBAuth::_ms_baseurl($auth_ms[1]) : null);
+emit('auth_auth_method_ms1', LBAuth::auth_method(1));

--- a/libs/phplib/testing/test_auth_unit.php
+++ b/libs/phplib/testing/test_auth_unit.php
@@ -1,0 +1,479 @@
+<?php
+// test_auth_unit.php - offline unit tests for loxberry_auth.php.
+// No Miniserver needed; the transport hook is replaced by a fake.
+// Run with an own LBHOMEDIR so the productive installation is untouched:
+//   LBHOMEDIR=/tmp/authhome php test_auth_unit.php
+
+$failed = 0;
+$count  = 0;
+function t_is($got, $exp, $name) {
+	global $failed, $count;
+	$count++;
+	if ($got == $exp) { echo "ok $count - $name\n"; return; }
+	$failed++;
+	echo "not ok $count - $name (got " . var_export($got, true)
+	   . ", expected " . var_export($exp, true) . ")\n";
+}
+function t_ok($cond, $name) { t_is($cond ? 1 : 0, 1, $name); }
+
+$home = getenv("LBHOMEDIR");
+if (!$home || strpos($home, "/tmp/") !== 0) {
+	fwrite(STDERR, "Refusing to run without a throwaway LBHOMEDIR below /tmp\n");
+	exit(2);
+}
+@mkdir("$home/config/system", 0755, true);
+@mkdir("$home/data/system", 0755, true);
+file_put_contents("$home/config/system/general.json", <<<'GENERALJSON'
+{
+  "Base": { "Lang": "de", "Version": "4.0.0.15" },
+  "Miniserver": {
+    "1": {
+      "Name": "Miniserver", "Ipaddress": "192.0.2.10",
+      "Admin": "loxberry", "Pass": "TestPass%2123",
+      "Port": 80, "Porthttps": 443, "Preferhttps": 0
+    },
+    "2": {
+      "Name": "MS Secure", "Ipaddress": "192.0.2.11",
+      "Admin": "admin", "Pass": "secret",
+      "Port": 80, "Porthttps": 4443, "Preferhttps": 1,
+      "Authmethod": "token"
+    },
+    "3": {
+      "Name": "MS IPv6", "Ipaddress": "fe80::1",
+      "Admin": "admin", "Pass": "secret",
+      "Port": 80, "Porthttps": 443, "Preferhttps": 0,
+      "Authmethod": "basicauth"
+    }
+  }
+}
+GENERALJSON
+);
+
+// The include_path is derived from LBHOMEDIR, which we just replaced by a
+// throwaway directory - so point PHP at the lib copy we are testing.
+set_include_path(get_include_path() . PATH_SEPARATOR . dirname(__DIR__));
+require_once dirname(__DIR__) . "/loxberry_auth.php";
+
+LBAuth::$store_file = "$home/data/system/tokens.json";
+@unlink(LBAuth::$store_file);
+
+// --- _norm_alg -------------------------------------------------------------
+t_is( LBAuth::_norm_alg('SHA256'),  'SHA256', 'norm_alg SHA256' );
+t_is( LBAuth::_norm_alg('sha-256'), 'SHA256', 'norm_alg sha-256 normalisiert' );
+t_is( LBAuth::_norm_alg('SHA1'),    'SHA1',   'norm_alg SHA1' );
+t_is( LBAuth::_norm_alg(null),      'SHA1',   'norm_alg leer faellt auf SHA1 zurueck' );
+t_is( LBAuth::_norm_alg('MD5'),     null,     'norm_alg unbekannt ist null' );
+
+// --- Hash-Kette, dieselben Referenzwerte wie im Perl-Test ------------------
+$KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+$pw256 = LBAuth::_pw_hash('Test1234', '41B0A8F1', 'SHA256');
+t_is( $pw256, '3E4A5D209675FD7633320D7F1AA5B399174D2B397ABE4FE53118FCECE38A847D', 'pw_hash SHA256' );
+t_is( LBAuth::_auth_hash('loxberry', $pw256, $KEY, 'SHA256'),
+      '31db6348ae60d52f53381bc3ebf2b7b1691a55e51110ef31ac50b19b1b2f9f47', 'auth_hash SHA256' );
+t_is( LBAuth::_token_hash('a1b2c3d4e5f60718293a4b5c6d7e8f90', $KEY, 'SHA256'),
+      '7c75d4ea7111e124200e9939ded8f9d2ece6835089a4d5ff1fb6d96e57b6dd65', 'token_hash SHA256' );
+$pw1 = LBAuth::_pw_hash('Test1234', '41B0A8F1', 'SHA1');
+t_is( $pw1, '3A09820F277977B59FE88D032BBC7ECF5C2C7BCD', 'pw_hash SHA1' );
+t_is( LBAuth::_auth_hash('loxberry', $pw1, $KEY, 'SHA1'),
+      'dde0f27175043736346411f693364a2bee2c0308', 'auth_hash SHA1' );
+t_is( LBAuth::_token_hash('a1b2c3d4e5f60718293a4b5c6d7e8f90', $KEY, 'SHA1'),
+      '9135606ae0eac2862b8536f0adc059cf57fd7e62', 'token_hash SHA1' );
+
+// --- _parse_api_value ------------------------------------------------------
+$apival = "{'snr': 'AB:CD:EF:01:02:03', 'version':'17.1.7.3', 'hasEventSlots':true, "
+        . "'isInTrust':false, 'local':true,'certTLD':'com'}";
+$api = LBAuth::_parse_api_value($apival);
+t_is( $api['snr'],     'AB:CD:EF:01:02:03', 'parse_api_value snr' );
+t_is( $api['version'], '17.1.7.3',          'parse_api_value version' );
+t_is( $api['certTLD'], 'com',               'parse_api_value certTLD' );
+t_is( $api['local'],   'true',              'parse_api_value unquotierter Wert' );
+t_is( LBAuth::_parse_api_value(''),   null, 'parse_api_value leer' );
+t_is( LBAuth::_parse_api_value(null), null, 'parse_api_value null' );
+
+// --- _fw_supported ---------------------------------------------------------
+t_is( LBAuth::_fw_supported('17.1.7.3'),   1, 'fw 17.1.7.3 unterstuetzt' );
+t_is( LBAuth::_fw_supported('11.2.10.22'), 1, 'fw exakt am Floor unterstuetzt' );
+t_is( LBAuth::_fw_supported('11.2.10.21'), 0, 'fw knapp unter Floor abgelehnt' );
+t_is( LBAuth::_fw_supported('11.2.9.99'),  0, 'fw aeltere Patchlinie abgelehnt' );
+t_is( LBAuth::_fw_supported('12.0'),       1, 'fw mit weniger Stellen unterstuetzt' );
+t_is( LBAuth::_fw_supported(''),           0, 'fw leer abgelehnt' );
+
+// --- _rights_granted -------------------------------------------------------
+t_is( LBAuth::_rights_granted(1924, LBAuth::PERM_SYSWS), 1, 'Sys-WS in 1924 enthalten' );
+t_is( LBAuth::_rights_granted(1924, LBAuth::PERM_APP),   1, 'App in 1924 enthalten' );
+t_is( LBAuth::_rights_granted(4,    LBAuth::PERM_SYSWS), 0, 'Sys-WS fehlt im reinen App-Token' );
+t_is( LBAuth::_rights_granted(1924, 0x104),              1, 'kombiniertes Bitmuster' );
+
+// --- Konstanten ------------------------------------------------------------
+t_is( LBAuth::$DEFAULT_PERM,      0x104,        'Standard-Permission App+Sys-WS' );
+t_is( LBAuth::$REFRESH_THRESHOLD, 7*86400,      'Erneuerungsschwelle 7 Tage' );
+t_is( LBAuth::$MIN_FIRMWARE,      '11.2.10.22', 'Firmware-Floor' );
+
+// --- Store -----------------------------------------------------------------
+t_is( LBAuth::_store_file(), "$home/data/system/tokens.json", 'store_file folgt dem Testhaken' );
+t_is( LBAuth::_store_read(), array(), 'fehlende Datei liefert leeres Array' );
+t_ok( !file_exists(LBAuth::$store_file), 'Lesen legt die Datei nicht an' );
+t_is( LBAuth::_store_get_token('AB:CD:EF:01:02:03', 'loxberry'), null, 'get_token auf leerem Bestand' );
+
+$msmeta = array( 'msnr' => 1, 'name' => 'Miniserver', 'is_lbsystem' => true,
+                 'lbsystem_user' => 'loxberry', 'firmware' => '17.1.7.3', 'checked' => 556606212 );
+$tok = array( 'token' => 'abc123', 'validUntil' => 564559554, 'rights' => 1924,
+              'perm' => 260, 'acquired' => 556606212, 'info' => 'LoxBerry testhost' );
+t_is( LBAuth::_store_put_token('AB:CD:EF:01:02:03', 'loxberry', $msmeta, $tok), 1, 'erstes put schreibt' );
+t_ok( file_exists(LBAuth::$store_file), 'Datei wurde angelegt' );
+clearstatcache();
+t_is( substr(sprintf('%o', fileperms(LBAuth::$store_file)), -4), '0600', 'Datei hat Rechte 0600' );
+
+$got = LBAuth::_store_get_token('AB:CD:EF:01:02:03', 'loxberry');
+t_is( $got['token'],      'abc123',  'Token gelesen' );
+t_is( $got['validUntil'], 564559554, 'validUntil gelesen' );
+
+$raw = json_decode(file_get_contents(LBAuth::$store_file), true);
+t_is( $raw['AB:CD:EF:01:02:03']['name'],     'Miniserver', 'Miniserver-Metadaten auf oberster Ebene' );
+t_is( $raw['AB:CD:EF:01:02:03']['firmware'], '17.1.7.3',   'firmware gespeichert' );
+t_ok( isset($raw['AB:CD:EF:01:02:03']['users']['loxberry']), 'Benutzer unter users' );
+t_ok( !isset($raw['AB:CD:EF:01:02:03']['users']['loxberry']['password']), 'kein Passwort im Bestand' );
+t_ok( !isset($raw['AB:CD:EF:01:02:03']['users']['loxberry']['key']),      'kein Einmalschluessel im Bestand' );
+
+clearstatcache();
+$mtime_before = filemtime(LBAuth::$store_file);
+sleep(1);
+t_is( LBAuth::_store_put_token('AB:CD:EF:01:02:03', 'loxberry', $msmeta, $tok), 0, 'unveraendertes put schreibt nicht' );
+clearstatcache();
+t_is( filemtime(LBAuth::$store_file), $mtime_before, 'mtime unveraendert' );
+
+$tok2 = $tok; $tok2['token'] = 'def456';
+t_is( LBAuth::_store_put_token('AB:CD:EF:01:02:03', 'loxberry', $msmeta, $tok2), 1, 'geaendertes put schreibt' );
+$g2 = LBAuth::_store_get_token('AB:CD:EF:01:02:03', 'loxberry');
+t_is( $g2['token'], 'def456', 'neuer Token gelesen' );
+
+LBAuth::_store_put_token('AB:CD:EF:01:02:03', 'sortmgr', $msmeta, $tok);
+$gs = LBAuth::_store_get_token('AB:CD:EF:01:02:03', 'sortmgr');
+$gl = LBAuth::_store_get_token('AB:CD:EF:01:02:03', 'loxberry');
+t_is( $gs['token'], 'abc123', 'zweiter Benutzer' );
+t_is( $gl['token'], 'def456', 'erster Benutzer unberuehrt' );
+t_is( LBAuth::_store_del_token('AB:CD:EF:01:02:03', 'sortmgr'), 1, 'del schreibt' );
+t_is( LBAuth::_store_get_token('AB:CD:EF:01:02:03', 'sortmgr'), null, 'Eintrag ist weg' );
+t_is( LBAuth::_store_del_token('AB:CD:EF:01:02:03', 'sortmgr'), 0, 'zweites del schreibt nicht' );
+
+file_put_contents(LBAuth::$store_file, "{ das ist kein json");
+t_is( LBAuth::_store_read(), array(), 'unlesbare Datei liefert leeres Array' );
+@unlink(LBAuth::$store_file);
+
+// --- _err ------------------------------------------------------------------
+$e = LBAuth::_err('unreachable', 'timed out');
+t_is( $e['ok'],      0,             'err ok ist 0' );
+t_is( $e['error'],   'unreachable', 'err code' );
+t_is( $e['message'], 'timed out',   'err message' );
+
+// --- _resolve_ms -----------------------------------------------------------
+$r = LBAuth::_resolve_ms(1);
+t_is( $r['ok'],            1,                         'resolve MS 1 ok' );
+t_is( $r['msnr'],          1,                         'msnr' );
+t_is( $r['name'],          'Miniserver',              'name' );
+t_is( $r['baseurl'],       'http://192.0.2.10:80', 'baseurl http' );
+t_is( $r['user'],          'loxberry',                'Benutzer aus general.json' );
+t_is( $r['password'],      'TestPass!23',              'Passwort aus Pass_RAW, nicht aus Pass' );
+t_is( $r['lbsystem_user'], 'loxberry',                'lbsystem_user' );
+$r2 = LBAuth::_resolve_ms(2);
+$r3 = LBAuth::_resolve_ms(3);
+t_is( $r2['baseurl'], 'https://192.0.2.11:4443', 'baseurl https mit eigenem Port' );
+t_is( $r3['baseurl'], 'http://[fe80::1]:80',        'IPv6 in eckigen Klammern' );
+
+$ru = LBAuth::_resolve_ms(1, array('user' => 'sortmgr', 'password' => 'geheim'));
+t_is( $ru['user'],     'sortmgr', 'uebergebener Benutzer' );
+t_is( $ru['password'], 'geheim',  'uebergebenes Passwort' );
+$rnp = LBAuth::_resolve_ms(1, array('user' => 'sortmgr'));
+t_is( $rnp['password'], null, 'kein Rueckfall auf das Passwort aus general.json' );
+
+$e9 = LBAuth::_resolve_ms(9);
+$en = LBAuth::_resolve_ms(null);
+$ee = LBAuth::_resolve_ms('');
+$es = LBAuth::_resolve_ms('AB:CD:EF:01:02:03');
+t_is( $e9['error'], 'msnotfound', 'MS 9 nicht konfiguriert' );
+t_is( $en['error'], 'msnotfound', 'null ist msnotfound' );
+t_is( $ee['error'], 'msnotfound', 'leer ist msnotfound' );
+t_is( $es['error'], 'msnotfound', 'unbekannte Seriennummer' );
+
+LBAuth::_store_put_token('AB:CD:EF:01:02:03', 'loxberry',
+	array('msnr' => 1, 'name' => 'Miniserver', 'firmware' => '17.1.7.3'),
+	array('token' => 'abc', 'validUntil' => 1, 'rights' => 1924));
+$rs = LBAuth::_resolve_ms('AB:CD:EF:01:02:03');
+$rl = LBAuth::_resolve_ms('ab:cd:ef:01:02:03');
+t_is( $rs['ok'],     1,                   'bekannte Seriennummer loest auf' );
+t_is( $rs['msnr'],   1,                   'Seriennummer -> msnr 1' );
+t_is( $rs['serial'], 'AB:CD:EF:01:02:03', 'serial durchgereicht' );
+t_is( $rl['msnr'],   1,                   'Seriennummer gross geschrieben verglichen' );
+
+// --- auth_method -----------------------------------------------------------
+t_is( LBAuth::auth_method(1), 'basicauth', 'fehlender Authmethod-Schluessel ist basicauth' );
+t_is( LBAuth::auth_method(2), 'token',     'Authmethod token' );
+t_is( LBAuth::auth_method(3), 'basicauth', 'Authmethod basicauth' );
+t_is( LBAuth::auth_method(9), 'basicauth', 'unbekannter Miniserver ist basicauth' );
+t_is( LBAuth::auth_method('AB:CD:EF:01:02:03'), 'basicauth', 'auth_method ueber die Seriennummer' );
+
+
+// ==========================================================================
+// Ablaeufe mit Fake-Transport
+// ==========================================================================
+@unlink(LBAuth::$store_file);
+// the process cache outlives the file - clear it, otherwise a token from the
+// store section above answers here
+LBAuth::_cache_clear();
+
+$KEY2 = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+$TOKHASH = '3b50109633af4140485302f72bd8a2734950286ca29a4633ef6c54376540bd69';
+$calls = array();
+$optlog = array();
+$behaviour = array(
+	'api_fw' => '17.1.7.3', 'api_serial' => 'AB:CD:EF:01:02:03',
+	'gettoken' => 'ok', 'rights' => 1924, 'validUntil' => 999999999,
+	'unreachable_all' => 0, 'refresh' => 'ok', 'kill' => 'ok', 'cmd_401_once' => 0,
+);
+
+LBAuth::$transport = function ($url, $opts) use (&$calls, &$optlog, &$behaviour, $KEY2) {
+	$calls[]  = $url;
+	$optlog[] = array('url' => $url, 'opts' => $opts);
+	if ($behaviour['unreachable_all']) { return array(null, null, 'Connection refused'); }
+
+	if (preg_match('#/jdev/cfg/api$#', $url)) {
+		$v = "{'snr': '" . $behaviour['api_serial'] . "', 'version':'" . $behaviour['api_fw']
+		   . "', 'hasEventSlots':true, 'isInTrust':false, 'local':true,'certTLD':'com'}";
+		return array(200, '{"LL": { "control": "dev/cfg/api", "value": "' . $v . '", "Code": "200"}}', '200 OK');
+	}
+	if (strpos($url, '/jdev/sys/getkey2/') !== false) {
+		return array(200, '{"LL":{"control":"dev/sys/getkey2","code":"200","value":{"key":"'
+		           . $KEY2 . '","salt":"41B0A8F1","hashAlg":"SHA256"}}}', '200 OK');
+	}
+	if (strpos($url, '/jdev/sys/gettoken/') !== false) {
+		if ($behaviour['gettoken'] == 'unreachable') { return array(null, null, 'Connection refused'); }
+		if ($behaviour['gettoken'] == '401') { return array(401, '<html><body>401</body></html>', '401 Unauthorized'); }
+		return array(200, '{"LL":{"control":"dev/sys/gettoken","code":"200","value":{"token":"tokTESTVALUE123","key":"'
+		           . $KEY2 . '","validUntil":' . $behaviour['validUntil'] . ',"tokenRights":'
+		           . $behaviour['rights'] . ',"unsecurePass":false}}}', '200 OK');
+	}
+	if (strpos($url, '/jdev/sys/refreshjwt/') !== false) {
+		if ($behaviour['refresh'] == '401') { return array(401, '<html>401</html>', '401 Unauthorized'); }
+		// Am echten Miniserver gemessen: HTTP 200, aber LL.code 401
+		if ($behaviour['refresh'] == 'll401') {
+			return array(200, '{"LL":{"control":"dev/sys/refreshjwt","value":{},"code":"401"}}', '200 OK');
+		}
+		return array(200, '{"LL":{"control":"dev/sys/refreshjwt","code":"200","value":{"token":"eyJ0eXAiTESTJWT","validUntil":'
+		           . $behaviour['validUntil'] . ',"tokenRights":1924,"unsecurePass":false}}}', '200 OK');
+	}
+	if (strpos($url, '/jdev/sys/killtoken/') !== false) {
+		if ($behaviour['kill'] == '401') { return array(401, '<html>401</html>', '401 Unauthorized'); }
+		return array(200, '{"LL":{"control":"dev/sys/killtoken","code":"200","value":"1"}}', '200 OK');
+	}
+	if (strpos($url, 'autht=') !== false) {
+		if ($behaviour['cmd_401_once'] > 0) {
+			$behaviour['cmd_401_once']--;
+			return array(401, '<html>401</html>', '401 Unauthorized');
+		}
+		return array(200, '{"LL":{"control":"dev/sps/io/Test","code":"200","value":"42"}}', '200 OK');
+	}
+	return array(404, 'not found', '404 Not Found');
+};
+
+// --- _ll_value / _ll_code / _effective_code -------------------------------
+$llv = LBAuth::_ll_value('{"LL":{"value":{"a":1},"Code":"200"}}');
+t_is( $llv['a'], 1, 'll_value Array' );
+t_is( LBAuth::_ll_value('{"LL":{"value":"text","Code":"200"}}'), 'text', 'll_value String' );
+t_is( LBAuth::_ll_value('<html>kaputt</html>'), null, 'll_value auf HTML ist null' );
+t_is( LBAuth::_ll_value(''), null, 'll_value auf leer ist null' );
+t_is( LBAuth::_ll_code('{"LL":{"value":{},"code":"401"}}'), 401, 'll_code liest kleines code' );
+t_is( LBAuth::_ll_code('{"LL":{"value":"x","Code":"200"}}'), 200, 'll_code liest grosses Code' );
+t_is( LBAuth::_ll_code('<html>401</html>'), null, 'll_code auf HTML ist null' );
+t_is( LBAuth::_effective_code(200, '{"LL":{"value":{},"code":"401"}}'), 401,
+      'HTTP 200 mit LL-Code 401 zaehlt als 401' );
+t_is( LBAuth::_effective_code(200, '{"LL":{"value":"x","Code":"200"}}'), 200, 'sauberer 200 bleibt 200' );
+t_is( LBAuth::_effective_code(401, '<html>401</html>'), 401, 'echter HTTP-Fehler bleibt' );
+
+// --- _client_uuid ----------------------------------------------------------
+$uuid = LBAuth::_client_uuid('loxberry');
+t_ok( preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/', $uuid), 'client_uuid hat UUID-Form' );
+t_is( LBAuth::_client_uuid('loxberry'), $uuid, 'client_uuid ist stabil' );
+t_ok( LBAuth::_client_uuid('sortmgr') != $uuid, 'client_uuid je Benutzer verschieden' );
+
+// --- _ms_api ---------------------------------------------------------------
+$api2 = LBAuth::_ms_api(LBAuth::_resolve_ms(1));
+t_is( $api2['ok'],       1,                   'ms_api ok' );
+t_is( $api2['serial'],   'AB:CD:EF:01:02:03', 'Seriennummer aus cfg/api' );
+t_is( $api2['firmware'], '17.1.7.3',          'Firmware aus cfg/api' );
+
+// --- get_token, Gutfall ----------------------------------------------------
+$calls = array();
+$t = LBAuth::get_token(1);
+t_is( $t['ok'],         1,                   'get_token ok' );
+t_is( $t['token'],      'tokTESTVALUE123',   'Token' );
+t_is( $t['validUntil'], 999999999,           'validUntil' );
+t_is( $t['rights'],     1924,                'rights' );
+t_is( $t['perm'],       260,                 'perm ist der Standard 0x104 = 260' );
+t_is( $t['serial'],     'AB:CD:EF:01:02:03', 'Seriennummer' );
+t_is( $t['firmware'],   '17.1.7.3',          'Firmware' );
+
+$gettoken_url = '';
+foreach ($calls as $c) { if (strpos($c, '/jdev/sys/gettoken/') !== false) { $gettoken_url = $c; } }
+t_ok( strpos($gettoken_url,
+      '/jdev/sys/gettoken/6811aac909afa7d530fd1cf87a28e4a9db15ad4e99eea57b33944319b05a86c5/loxberry/260/') !== false,
+      'authHash, Benutzer und perm stehen korrekt in der URL' );
+
+$stored = LBAuth::_store_get_token('AB:CD:EF:01:02:03', 'loxberry');
+t_is( $stored['token'], 'tokTESTVALUE123', 'Token persistiert' );
+t_ok( !isset($stored['key']),      'Einmalschluessel nicht persistiert' );
+t_ok( !isset($stored['password']), 'Passwort nicht persistiert' );
+
+$calls = array();
+$tc = LBAuth::get_token(1);
+t_is( $tc['token'], 'tokTESTVALUE123', 'zweiter Aufruf liefert denselben Token' );
+t_is( count($calls), 0, 'zweiter Aufruf macht keinen HTTP-Request' );
+
+$calls = array();
+LBAuth::get_token(1, array('force' => 1));
+t_ok( count($calls) >= 2, 'force holt neu' );
+$tser = LBAuth::get_token('AB:CD:EF:01:02:03');
+t_is( $tser['ok'], 1, 'get_token ueber die Seriennummer' );
+
+// --- Fehlerfaelle ----------------------------------------------------------
+$behaviour['rights'] = 4;
+$tr = LBAuth::get_token(1, array('force' => 1));
+t_is( $tr['error'], 'missingright', 'fehlendes Recht ist missingright' );
+$behaviour['rights'] = 1924;
+
+$behaviour['gettoken'] = '401';
+$tb = LBAuth::get_token(1, array('force' => 1));
+t_is( $tb['error'], 'badcredentials',
+      'badcredentials - der 401 kommt bei gettoken, nicht bei getkey2' );
+$behaviour['gettoken'] = 'ok';
+
+$behaviour['api_fw'] = '11.2.10.21';
+$calls = array();
+$tf = LBAuth::get_token(1, array('force' => 1));
+t_is( $tf['error'], 'fwtooold', 'zu alte Firmware ist fwtooold' );
+$syscalls = 0;
+foreach ($calls as $c) { if (strpos($c, '/jdev/sys/') !== false) { $syscalls++; } }
+t_is( $syscalls, 0, 'bei zu alter Firmware wird kein Token angefragt' );
+$behaviour['api_fw'] = '17.1.7.3';
+
+$behaviour['unreachable_all'] = 1;
+$tu = LBAuth::get_token(1, array('force' => 1));
+t_is( $tu['error'], 'unreachable', 'nicht erreichbar' );
+$behaviour['unreachable_all'] = 0;
+
+$calls = array();
+$tn = LBAuth::get_token(1, array('user' => 'sortmgr'));
+t_is( $tn['error'], 'nocredentials', 'fremder Benutzer ohne Passwort ist nocredentials' );
+t_is( count($calls), 0, 'ohne Passwort wird gar nicht erst gefragt' );
+
+$tx = LBAuth::get_token(1, array('user' => 'sortmgr', 'password' => 'geheim', 'perm' => 0x04));
+t_is( $tx['ok'],   1,         'fremder Benutzer mit Passwort bekommt einen Token' );
+t_is( $tx['perm'], 4,         'uebergebene Permission wird verwendet' );
+t_is( $tx['user'], 'sortmgr', 'Token gehoert dem fremden Benutzer' );
+
+// --- token_info / request / refresh / kill ---------------------------------
+LBAuth::_store_put_token('AB:CD:EF:01:02:03', 'loxberry',
+	array('msnr' => 1, 'name' => 'Miniserver', 'firmware' => '17.1.7.3'),
+	array('token' => 'tokTESTVALUE123', 'validUntil' => epoch2lox() + 60*86400,
+	      'rights' => 1924, 'perm' => 260, 'acquired' => 1, 'info' => 'LoxBerry testhost'));
+
+$ti = LBAuth::token_info(1);
+t_is( $ti['ok'],     1,                   'token_info ok' );
+t_is( $ti['token'],  'tokTESTVALUE123',   'token_info Token' );
+t_is( $ti['serial'], 'AB:CD:EF:01:02:03', 'token_info Seriennummer' );
+t_ok( $ti['expires_in'] > 59*86400, 'token_info Restlaufzeit' );
+$tni = LBAuth::token_info(1, array('user' => 'niemand'));
+t_is( $tni['error'], 'notoken', 'token_info ohne Bestand' );
+
+$calls = array();
+list($content, $info) = LBAuth::request(1, '/jdev/sps/io/Test');
+t_is( $info['code'],  200, 'request code 200' );
+t_is( $info['error'], 0,   'request error 0' );
+t_ok( strpos($content, '"value":"42"') !== false, 'request liefert den Body' );
+$cmd_url = '';
+foreach ($calls as $c) { if (strpos($c, '/jdev/sps/io/Test') !== false) { $cmd_url = $c; } }
+t_ok( strpos($cmd_url, '?autht=' . $TOKHASH . '&user=loxberry') !== false,
+      'autht traegt den Token-Hash, user haengt an' );
+
+$calls = array();
+LBAuth::request(1, '/jdev/sps/io/Test?state=on');
+$q_url = '';
+foreach ($calls as $c) { if (strpos($c, '/jdev/sps/io/Test') !== false) { $q_url = $c; } }
+t_ok( strpos($q_url, '?state=on&autht=') !== false, 'vorhandener Query-String wird mit & ergaenzt' );
+
+$calls = array();
+$behaviour['cmd_401_once'] = 1;
+list($c2, $i2) = LBAuth::request(1, '/jdev/sps/io/Test');
+t_is( $i2['error'], 0, '401 fuehrt zu einem erfolgreichen zweiten Versuch' );
+$behaviour['cmd_401_once'] = 2;
+list($c3, $i3) = LBAuth::request(1, '/jdev/sps/io/Test');
+t_is( $i3['errcode'], 'revoked', 'zweimal 401 ist revoked' );
+$behaviour['cmd_401_once'] = 0;
+
+LBAuth::_store_put_token('AB:CD:EF:01:02:03', 'loxberry', array('msnr' => 1),
+	array('token' => 'tokTESTVALUE123', 'validUntil' => epoch2lox() + 3*86400,
+	      'rights' => 1924, 'perm' => 260, 'acquired' => 1, 'info' => 'x'));
+$calls = array();
+LBAuth::request(1, '/jdev/sps/io/Test');
+$refreshcalls = 0;
+foreach ($calls as $c) { if (strpos($c, '/jdev/sys/refreshjwt/') !== false) { $refreshcalls++; } }
+t_is( $refreshcalls, 1, 'Restlaufzeit unter 7 Tagen loest refreshjwt aus' );
+$after = LBAuth::_store_get_token('AB:CD:EF:01:02:03', 'loxberry');
+t_is( $after['token'], 'eyJ0eXAiTESTJWT', 'der erneuerte JWT ersetzt den alten Token im Bestand' );
+
+$rt = LBAuth::refresh_token(1);
+t_is( $rt['ok'],    1,                 'refresh_token ok' );
+t_is( $rt['token'], 'eyJ0eXAiTESTJWT', 'refresh_token liefert den JWT' );
+
+// autht traegt den Klartext-Token, der Pfad den Hash
+$calls = array();
+LBAuth::refresh_token(1);
+$rj_url = '';
+foreach ($calls as $c) { if (strpos($c, '/jdev/sys/refreshjwt/') !== false) { $rj_url = $c; } }
+t_ok( preg_match('#/jdev/sys/refreshjwt/[0-9a-f]{64}/loxberry\?autht=#', $rj_url),
+      'refreshjwt: Token-Hash im Pfad' );
+t_ok( strpos($rj_url, 'autht=eyJ0eXAiTESTJWT&') !== false,
+      'refreshjwt: autht ist der Klartext-Token, nicht der Hash' );
+
+$behaviour['refresh'] = '401';
+$r401 = LBAuth::refresh_token(1);
+t_is( $r401['error'], 'revoked', '401 bei refreshjwt ist revoked' );
+$behaviour['refresh'] = 'll401';
+$rll = LBAuth::refresh_token(1);
+t_is( $rll['error'], 'revoked', 'HTTP 200 mit LL-Code 401 wird als Ablehnung erkannt' );
+$behaviour['refresh'] = 'ok';
+
+$knp = LBAuth::kill_token(1, array('user' => 'sortmgr'));
+t_is( $knp['error'], 'nopassword', 'kill_token ohne Passwort' );
+$optlog = array();
+$kt = LBAuth::kill_token(1);
+t_is( $kt['ok'], 1, 'kill_token mit dem Passwort aus general.json' );
+$killopts = null;
+foreach ($optlog as $o) { if (strpos($o['url'], '/jdev/sys/killtoken/') !== false) { $killopts = $o['opts']; } }
+t_is( $killopts['basicauth_user'],     'loxberry',   'killtoken nutzt Basic-Auth' );
+t_is( $killopts['basicauth_password'], 'TestPass!23', 'Basic-Auth mit dem Klartext-Passwort' );
+t_is( LBAuth::_store_get_token('AB:CD:EF:01:02:03', 'loxberry'), null, 'Eintrag nach kill_token entfernt' );
+
+// --- Prozess-Cache ---------------------------------------------------------
+LBAuth::_cache_clear();
+LBAuth::_store_put_token('AA:BB:CC:DD:EE:FF', 'cacheuser', array('msnr' => 1),
+	array('token' => 'cached1', 'validUntil' => 5, 'rights' => 1924));
+@unlink(LBAuth::$store_file);
+$cc = LBAuth::_store_get_token('AA:BB:CC:DD:EE:FF', 'cacheuser');
+t_is( $cc['token'], 'cached1', 'get_token bedient sich aus dem Prozess-Cache' );
+LBAuth::_cache_clear();
+t_is( LBAuth::_store_get_token('AA:BB:CC:DD:EE:FF', 'cacheuser'), null,
+      'ohne Cache und ohne Datei ist nichts mehr da' );
+LBAuth::_store_put_token('AA:BB:CC:DD:EE:FF', 'cacheuser', array('msnr' => 1),
+	array('token' => 'cached2', 'validUntil' => 5, 'rights' => 1924));
+$cc2 = LBAuth::_store_get_token('AA:BB:CC:DD:EE:FF', 'cacheuser');
+t_is( $cc2['token'], 'cached2', 'put aktualisiert den Cache' );
+LBAuth::_store_del_token('AA:BB:CC:DD:EE:FF', 'cacheuser');
+t_is( LBAuth::_store_get_token('AA:BB:CC:DD:EE:FF', 'cacheuser'), null, 'del raeumt den Cache mit' );
+
+echo "
+1..$count
+";
+echo $failed ? "$failed FAILED
+" : "ALL OK
+";
+exit($failed ? 1 : 0);

--- a/libs/phplib/testing/testauth.php
+++ b/libs/phplib/testing/testauth.php
@@ -1,0 +1,101 @@
+<?php
+// testauth.php - loxberry_auth.php against a real Miniserver.
+// Runs on a live LoxBerry.
+//
+//   php testauth.php [msnr|serial] [--store <path>] [--keep]
+//
+// Without --store the token is kept in /tmp so the productive
+// data/system/tokens.json is not touched. Without --keep the token is revoked
+// at the end - the Miniserver must not collect orphans in its token list.
+
+require_once "loxberry_system.php";
+set_include_path(get_include_path() . PATH_SEPARATOR . dirname(__DIR__));
+require_once dirname(__DIR__) . "/loxberry_auth.php";
+
+$args  = array_slice($argv, 1);
+$ms    = (isset($args[0]) && substr($args[0], 0, 2) !== '--') ? array_shift($args) : 1;
+$keep  = false;
+$store = "/tmp/testauth_tokens_php.json";
+while ($a = array_shift($args)) {
+	if ($a === '--keep')  { $keep = true; }
+	if ($a === '--store') { $store = array_shift($args); }
+}
+LBAuth::$store_file = $store;
+
+echo "Miniserver : $ms\n";
+echo "Token store: $store\n";
+echo "auth_method: " . LBAuth::auth_method($ms) . "\n";
+
+$failed = 0;
+function step($name, $res) {
+	global $failed;
+	if (is_array($res) && !empty($res['ok'])) { echo "OK   $name\n"; return true; }
+	$failed++;
+	echo "FAIL $name: " . (isset($res['error']) ? $res['error'] : '?')
+	   . " - " . (isset($res['message']) ? $res['message'] : '') . "\n";
+	return false;
+}
+
+echo "\n=== get_token ===\n";
+$t = LBAuth::get_token($ms, array('info' => 'LoxBerry Auth selftest PHP', 'force' => 1));
+if (step('get_token', $t)) {
+	printf("     serial     : %s\n", $t['serial']);
+	printf("     firmware   : %s\n", $t['firmware']);
+	printf("     perm       : %d (0x%x)\n", $t['perm'], $t['perm']);
+	printf("     rights     : %d\n", $t['rights']);
+	printf("     validUntil : %d (lox) = %s\n", $t['validUntil'],
+	       date('Y-m-d H:i:s', lox2epoch($t['validUntil'])));
+	$days = ($t['validUntil'] - epoch2lox()) / 86400;
+	printf("     lifetime   : %.1f days%s\n", $days,
+	       $days > 80 ? ' (matches the ~3 months measured for 0x104)' : ' (SHORTER THAN EXPECTED)');
+	printf("     Sys-WS bit : %s\n",
+	       LBAuth::_rights_granted($t['rights'], LBAuth::PERM_SYSWS)
+	       ? 'granted - reboot would be allowed' : 'MISSING');
+}
+
+echo "\n=== token_info ===\n";
+$ti = LBAuth::token_info($ms);
+step('token_info', $ti);
+if (!empty($ti['ok'])) { printf("     expires_in : %d s\n", $ti['expires_in']); }
+
+echo "\n=== request /jdev/cfg/version ===\n";
+list($content, $info) = LBAuth::request($ms, '/jdev/cfg/version');
+if ($info['error'] == 0) {
+	echo "OK   request (code " . $info['code'] . ")\n     $content\n";
+} else {
+	$failed++;
+	echo "FAIL request: " . $info['errcode'] . " - " . $info['message'] . "\n";
+}
+
+echo "\n=== second request: the one-time key must be fetched again ===\n";
+list($c2, $i2) = LBAuth::request($ms, '/jdev/cfg/version');
+if ($i2['error'] == 0) { echo "OK   second request (code " . $i2['code'] . ")\n"; }
+else { $failed++; echo "FAIL second request: " . $i2['errcode'] . " - " . $i2['message'] . "\n"; }
+
+echo "\n=== refresh_token (password free) ===\n";
+$rt = LBAuth::refresh_token($ms);
+if (step('refresh_token', $rt)) {
+	printf("     token      : %s...\n", substr($rt['token'], 0, 12));
+	printf("     format     : %s\n", substr($rt['token'], 0, 3) === 'eyJ' ? 'JWT' : 'hex');
+}
+
+echo "\n=== request with the refreshed token ===\n";
+list($c3, $i3) = LBAuth::request($ms, '/jdev/cfg/version');
+if ($i3['error'] == 0) { echo "OK   request after refresh (code " . $i3['code'] . ")\n"; }
+else { $failed++; echo "FAIL request after refresh: " . $i3['errcode'] . " - " . $i3['message'] . "\n"; }
+
+echo "\n=== cleanup: kill_token ===\n";
+if ($keep) {
+	echo "SKIP --keep given - the token stays on the Miniserver\n";
+} else {
+	step('kill_token', LBAuth::kill_token($ms));
+	$after = LBAuth::token_info($ms);
+	if (empty($after['ok']) && $after['error'] === 'notoken') { echo "OK   store entry removed\n"; }
+	else { $failed++; echo "FAIL store entry still present\n"; }
+	// a request re-fetches a token automatically - that one has to go as well
+	LBAuth::request($ms, '/jdev/cfg/version');
+	LBAuth::kill_token($ms);
+}
+
+echo "\n" . ($failed ? "$failed STEP(S) FAILED\n" : "ALL STEPS OK\n");
+exit($failed ? 1 : 0);

--- a/libs/pythonlib/loxberry/auth.py
+++ b/libs/pythonlib/loxberry/auth.py
@@ -1,0 +1,844 @@
+# -*- coding: utf-8 -*-
+"""
+loxberry.auth - Python port of LoxBerry::Auth.
+
+Token authentication at the Loxone Miniserver. Mirrors the Perl master
+(libs/perllib/LoxBerry/Auth.pm) 1:1 - same function names, same dict keys.
+
+Standard library only: hashlib, hmac, urllib, json, fcntl, base64.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json as _json
+import os
+import re
+import ssl
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+try:
+    import fcntl  # POSIX only - Windows dev machines run without the lock
+    _HAVE_FCNTL = True
+except ImportError:
+    _HAVE_FCNTL = False
+
+from . import system as _lb
+
+DEBUG = 0
+
+# Permission bits of the Miniserver token API
+PERM_ADMIN = 0x01
+PERM_WEB = 0x02
+PERM_APP = 0x04
+PERM_SYSWS = 0x100
+
+# App + Sys-WS: ~3 months lifetime, includes the right to reboot
+DEFAULT_PERM = 0x104
+# Renew as soon as less than this many seconds are left
+REFRESH_THRESHOLD = 7 * 86400
+TIMEOUT = 10
+# Below this firmware the token endpoints need application layer encryption
+MIN_FIRMWARE = "11.2.10.22"
+
+# Test hooks - the unit tests replace these module attributes
+store_file = None
+transport = None
+
+
+def _dbg(msg: str) -> None:
+    if DEBUG:
+        sys.stderr.write("loxberry.auth: %s\n" % msg)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers - no I/O, no state
+# ---------------------------------------------------------------------------
+def _norm_alg(alg):
+    """An empty hashAlg means SHA1 (Miniservers from before the field existed)."""
+    alg = "" if alg is None else str(alg).upper()
+    alg = re.sub(r"[^A-Z0-9]", "", alg)
+    if alg in ("", "SHA1"):
+        return "SHA1"
+    if alg == "SHA256":
+        return "SHA256"
+    return None
+
+
+def _digest(alg):
+    return hashlib.sha256 if alg == "SHA256" else hashlib.sha1
+
+
+def _hash_hex(alg, data) -> str:
+    return _digest(alg)(data.encode("utf-8")).hexdigest()
+
+
+def _hmac_hex(alg, data, keyhex) -> str:
+    """The key from getkey2 is hex encoded and used as raw bytes."""
+    return hmac.new(bytes.fromhex(keyhex), data.encode("utf-8"), _digest(alg)).hexdigest()
+
+
+def _pw_hash(password, salt, alg) -> str:
+    """The Miniserver expects the password hash in uppercase."""
+    return _hash_hex(alg, "%s:%s" % (password, salt)).upper()
+
+
+def _auth_hash(user, pwhash, keyhex, alg) -> str:
+    return _hmac_hex(alg, "%s:%s" % (user, pwhash), keyhex)
+
+
+def _token_hash(token, keyhex, alg) -> str:
+    return _hmac_hex(alg, token, keyhex)
+
+
+def _parse_api_value(value):
+    """jdev/cfg/api returns its value as a STRING using single quotes - that is
+    not valid JSON and must not be fed to json.loads()."""
+    if not value:
+        return None
+    out = {}
+    for m in re.finditer(r"'([^']+)'\s*:\s*(?:'([^']*)'|([^,}\s]+))", value):
+        out[m.group(1)] = m.group(2) if m.group(2) is not None else m.group(3)
+    return out or None
+
+
+def _fw_supported(fw) -> int:
+    if not fw:
+        return 0
+    is_ = str(fw).split(".")
+    mn = MIN_FIRMWARE.split(".")
+    for i in range(4):
+        a = int(is_[i]) if i < len(is_) and is_[i].isdigit() else 0
+        b = int(mn[i]) if i < len(mn) else 0
+        if a > b:
+            return 1
+        if a < b:
+            return 0
+    return 1
+
+
+def _rights_granted(rights, bit) -> int:
+    """tokenRights is a bitmask; perm 0x104 was measured to return 1924."""
+    if rights is None or bit is None:
+        return 0
+    return 1 if (int(rights) & int(bit)) == int(bit) else 0
+
+
+# ---------------------------------------------------------------------------
+# Token store - data/system/tokens.json, 0600, owner loxberry
+# ---------------------------------------------------------------------------
+def _store_file():
+    if store_file:
+        return store_file
+    if getattr(_lb, "lbsdatadir", None):
+        return "%s/tokens.json" % _lb.lbsdatadir
+    return None
+
+
+def _store_decode(content):
+    if not content or not content.strip():
+        return {}
+    try:
+        data = _json.loads(content)
+    except ValueError:
+        _dbg("tokens.json is not readable JSON - starting empty")
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _store_encode(data) -> str:
+    return _json.dumps(data, indent=3, sort_keys=True, ensure_ascii=False)
+
+
+def _store_read():
+    """Read the full store under a shared lock. A missing file is an empty
+    store and is NOT created here."""
+    path = _store_file()
+    if not path or not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            if _HAVE_FCNTL:
+                try:
+                    fcntl.flock(fh, fcntl.LOCK_SH)
+                except OSError:
+                    pass
+            content = fh.read()
+    except OSError as exc:
+        _dbg("cannot open %s: %s" % (path, exc))
+        return {}
+    return _store_decode(content)
+
+
+def _store_update(cb):
+    """Read-modify-write under ONE exclusive lock. cb(data) mutates the dict in
+    place. Returns 1 = written, 0 = unchanged, None = error."""
+    path = _store_file()
+    if not path:
+        _dbg("no token store path available")
+        return None
+    try:
+        fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+    except OSError as exc:
+        _dbg("cannot open %s: %s" % (path, exc))
+        return None
+
+    try:
+        with os.fdopen(fd, "r+", encoding="utf-8") as fh:
+            if _HAVE_FCNTL:
+                try:
+                    fcntl.flock(fh, fcntl.LOCK_EX)
+                except OSError:
+                    pass
+            content = fh.read()
+            data = _store_decode(content)
+            before = _store_encode(data)
+
+            cb(data)
+
+            after = _store_encode(data)
+            if after == before and content.strip():
+                return 0
+
+            fh.seek(0)
+            fh.write(after)
+            fh.truncate()
+    except OSError as exc:
+        _dbg("cannot write %s: %s" % (path, exc))
+        return None
+
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+    try:
+        import pwd
+
+        entry = pwd.getpwnam("loxberry")
+        os.chown(path, entry.pw_uid, entry.pw_gid)
+    except Exception:
+        pass
+    return 1
+
+
+# Process cache: the token lives in the process, the file is pure persistence
+# across restarts. Another process may change the file behind our back - the
+# single 401 retry in request() is the safety net for that.
+_tokencache = {}
+
+
+def _cache_clear():
+    _tokencache.clear()
+    return 1
+
+
+def _store_get_token(serial, user):
+    if not serial or not user:
+        return None
+    ck = "%s|%s" % (serial, user)
+    if ck in _tokencache:
+        return _tokencache[ck]
+
+    data = _store_read()
+    tok = data.get(serial, {}).get("users", {}).get(user)
+    if tok:
+        _tokencache[ck] = tok
+    return tok
+
+
+def _store_put_token(serial, user, msmeta, tokendata):
+    if not serial or not user:
+        return None
+    _tokencache["%s|%s" % (serial, user)] = dict(tokendata)
+
+    def _cb(data):
+        entry = data.setdefault(serial, {})
+        entry.update(msmeta)
+        entry.setdefault("users", {})[user] = dict(tokendata)
+
+    return _store_update(_cb)
+
+
+def _store_del_token(serial, user):
+    if not serial or not user:
+        return None
+    _tokencache.pop("%s|%s" % (serial, user), None)
+
+    def _cb(data):
+        data.get(serial, {}).get("users", {}).pop(user, None)
+
+    return _store_update(_cb)
+
+
+# ---------------------------------------------------------------------------
+# Result objects
+# ---------------------------------------------------------------------------
+def _err(code, message):
+    _dbg("%s - %s" % (code, message))
+    return {"ok": 0, "error": code, "message": message}
+
+
+# ---------------------------------------------------------------------------
+# Miniserver resolution
+# ---------------------------------------------------------------------------
+def _ms_baseurl(msc):
+    if not msc:
+        return None
+    transport_ = msc.get("Transport") or "http"
+    port = msc.get("PortHttps") if transport_ == "https" else msc.get("Port")
+    if not port:
+        port = 443 if transport_ == "https" else 80
+    ip = msc.get("IPAddress") or ""
+    if ":" in ip:
+        ip = "[%s]" % ip
+    return "%s://%s:%s" % (transport_, ip, port)
+
+
+def _resolve_ms(ms, **opts):
+    """Accepts a Miniserver number or a serial. A serial is resolved through the
+    token store. With a user but without a password the password stays None on
+    purpose - the password from general.json belongs to that user only."""
+    if ms is None or ms == "":
+        return _err("msnotfound", "No Miniserver given")
+
+    serial = None
+    msnr = None
+    if re.match(r"^\d+$", str(ms)):
+        msnr = str(ms)
+    else:
+        serial = str(ms).upper()
+        data = _store_read()
+        msnr = data.get(serial, {}).get("msnr")
+        if msnr is None:
+            return _err("msnotfound",
+                        "Serial %s is unknown - fetch a token for this Miniserver first" % ms)
+        msnr = str(msnr)
+
+    miniservers = _lb.get_miniservers() or {}
+    msc = miniservers.get(msnr)
+    if not msc:
+        return _err("msnotfound", "Miniserver %s is not configured" % ms)
+
+    user = opts["user"] if opts.get("user") is not None else msc.get("Admin_RAW")
+    if opts.get("password") is not None:
+        password = opts["password"]
+    else:
+        password = None if opts.get("user") is not None else msc.get("Pass_RAW")
+
+    return {
+        "ok": 1,
+        "msnr": msnr,
+        "name": msc.get("Name"),
+        "baseurl": _ms_baseurl(msc),
+        "user": user,
+        "password": password,
+        "serial": serial,
+        "is_lbsystem": 1,
+        "lbsystem_user": msc.get("Admin_RAW"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# general.json: Authmethod (read only - never written by this lib)
+# ---------------------------------------------------------------------------
+def auth_method(ms) -> str:
+    if ms is None or ms == "":
+        return "basicauth"
+
+    msnr = str(ms)
+    if not re.match(r"^\d+$", msnr):
+        data = _store_read()
+        entry = data.get(str(ms).upper())
+        if not entry or entry.get("msnr") is None:
+            return "basicauth"
+        msnr = str(entry["msnr"])
+
+    try:
+        with open("%s/general.json" % _lb.lbsconfigdir, "r", encoding="utf-8") as fh:
+            cfg = _json.load(fh)
+    except (OSError, ValueError):
+        return "basicauth"
+    if not isinstance(cfg, dict):
+        return "basicauth"
+
+    val = cfg.get("Miniserver", {}).get(msnr, {}).get("Authmethod")
+    if val is not None and str(val).lower() == "token":
+        return "token"
+    return "basicauth"
+
+
+# ---------------------------------------------------------------------------
+# HTTP transport
+# Verified on Miniserver 17.1.7.3: jdev/cfg/api and jdev/sys/getkey2 answer
+# without any authentication. Only killtoken needs Basic Auth.
+# ---------------------------------------------------------------------------
+def _http_get(url, **opts):
+    """Returns (code, body, status). code is None when no connection happened."""
+    req = urllib.request.Request(url)
+    if opts.get("basicauth_user") is not None:
+        import base64
+
+        raw = "%s:%s" % (opts["basicauth_user"], opts.get("basicauth_password") or "")
+        req.add_header("Authorization",
+                       "Basic " + base64.b64encode(raw.encode("utf-8")).decode("ascii"))
+
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    try:
+        with urllib.request.urlopen(req, timeout=opts.get("timeout") or TIMEOUT,
+                                    context=ctx) as resp:
+            body = resp.read().decode("utf-8", "replace")
+            return (resp.status, body, "%s" % resp.status)
+    except urllib.error.HTTPError as exc:
+        # an HTTP status - not a connection problem
+        try:
+            body = exc.read().decode("utf-8", "replace")
+        except Exception:
+            body = ""
+        return (exc.code, body, "%s %s" % (exc.code, exc.reason))
+    except Exception as exc:
+        return (None, None, str(exc))
+
+
+# Only these options concern the transport. get_token() and friends also carry
+# user/password/perm/force in opts - passing those through would collide with
+# the positional "user" parameter of _getkey2() and would leak credentials into
+# the transport hook.
+_CALL_KEYS = ("timeout", "basicauth_user", "basicauth_password")
+
+
+def _call_opts(opts):
+    return dict((k, v) for k, v in opts.items() if k in _CALL_KEYS)
+
+
+def _call(url, **opts):
+    _dbg("GET %s" % url)
+    t = transport if transport else _http_get
+    return t(url, **_call_opts(opts))
+
+
+def _ll_value(body):
+    """The LL envelope. value is a dict for most endpoints and a string for
+    jdev/cfg/api. A non-JSON body (401 comes back as HTML) is None."""
+    if not body or not body.strip():
+        return None
+    try:
+        j = _json.loads(body)
+    except ValueError:
+        return None
+    if not isinstance(j, dict) or not isinstance(j.get("LL"), dict):
+        return None
+    return j["LL"].get("value")
+
+
+def _ll_code(body):
+    """The LL envelope carries its OWN status code, and the Miniserver does not
+    always mirror it into the HTTP status: refreshjwt answers HTTP 200 with
+    LL.code 401 when the token signature is not accepted. Measured on 17.1.7.3.
+    The field is spelled "Code" by some endpoints (jdev/cfg/api) and "code" by
+    others (jdev/sys/*), so both are read."""
+    if not body or not body.strip():
+        return None
+    try:
+        j = _json.loads(body)
+    except ValueError:
+        return None
+    if not isinstance(j, dict) or not isinstance(j.get("LL"), dict):
+        return None
+    c = j["LL"].get("code", j["LL"].get("Code"))
+    if c is None or not re.match(r"^\d+$", str(c)):
+        return None
+    return int(c)
+
+
+def _effective_code(code, body):
+    """The code that really decides: an HTTP 200 carrying a different LL code is
+    a failure, not a success."""
+    if code is None or code != 200:
+        return code
+    ll = _ll_code(body)
+    if ll is not None and ll != 200:
+        return ll
+    return code
+
+
+def _client_uuid(user) -> str:
+    """Stable per host and user, so the Miniserver does not collect a new client
+    entry on every call. Derived, never persisted."""
+    seed = "%s|%s|loxberry-auth" % (_lb.lbhostname(), user)
+    h = hashlib.sha256(seed.encode("utf-8")).hexdigest()
+    return "%s-%s-%s-%s-%s" % (h[0:8], h[8:12], h[12:16], h[16:20], h[20:32])
+
+
+# ---------------------------------------------------------------------------
+# Miniserver identity: serial + firmware in one call
+# ---------------------------------------------------------------------------
+def _ms_api(res, **opts):
+    code, body, _status = _call(res["baseurl"] + "/jdev/cfg/api", **opts)
+    if code is None:
+        return _err("unreachable", "%s did not answer" % res["baseurl"])
+    code = _effective_code(code, body)
+    if code != 200:
+        return _err("httperror", "jdev/cfg/api returned %s" % code)
+
+    api = _parse_api_value(_ll_value(body))
+    if not api:
+        return _err("parseerror", "jdev/cfg/api could not be parsed")
+    if not api.get("snr"):
+        return _err("parseerror", "jdev/cfg/api has no serial")
+    return {"ok": 1, "serial": api["snr"].upper(), "firmware": api.get("version", "")}
+
+
+def _getkey2(res, user, **opts):
+    url = res["baseurl"] + "/jdev/sys/getkey2/" + urllib.parse.quote(str(user), safe="")
+    code, body, _status = _call(url, **opts)
+    if code is None:
+        return _err("unreachable", "%s did not answer" % res["baseurl"])
+    code = _effective_code(code, body)
+    if code == 401:
+        return _err("badcredentials", "getkey2 returned %s for user %s" % (code, user))
+    if code != 200:
+        return _err("httperror", "getkey2 returned %s" % code)
+
+    v = _ll_value(body)
+    if not isinstance(v, dict):
+        return _err("parseerror", "getkey2 could not be parsed")
+    alg = _norm_alg(v.get("hashAlg"))
+    if not alg:
+        return _err("parseerror", "getkey2 returned an unknown hashAlg")
+    return {"ok": 1, "key": v.get("key"), "salt": v.get("salt"), "alg": alg}
+
+
+def _serial_from_store(msnr):
+    """The serial of a Miniserver number, as far as an earlier run persisted it.
+    Looking it up here keeps get_token free of HTTP when a token is cached."""
+    data = _store_read()
+    for s in sorted(data.keys()):
+        if str(data[s].get("msnr")) == str(msnr):
+            return (s, data[s].get("firmware"))
+    return (None, None)
+
+
+def _resolve_ms_probing(ms, **opts):
+    """Like _resolve_ms, but an unknown serial makes every configured Miniserver
+    be asked for its own serial. That is the only way a serial enters the store."""
+    res = _resolve_ms(ms, **opts)
+    if res["ok"]:
+        return res
+    if re.match(r"^\d+$", str(ms)):
+        return res
+
+    want = str(ms).upper()
+    miniservers = _lb.get_miniservers() or {}
+    for msnr in sorted(miniservers.keys(), key=lambda k: int(k) if str(k).isdigit() else 0):
+        cand = _resolve_ms(msnr, **opts)
+        if not cand["ok"]:
+            continue
+        api = _ms_api(cand, **_call_opts(opts))
+        if not api["ok"] or api["serial"] != want:
+            continue
+        cand["serial"] = want
+        cand["firmware"] = api["firmware"]
+        return cand
+    return _err("msnotfound", "No configured Miniserver has serial %s" % ms)
+
+
+# ---------------------------------------------------------------------------
+# get_token
+# ---------------------------------------------------------------------------
+def get_token(ms, **opts):
+    res = _resolve_ms_probing(ms, **opts)
+    if not res["ok"]:
+        return res
+
+    user = res["user"]
+    if not user:
+        return _err("nocredentials", "No user for Miniserver %s" % ms)
+
+    perm = int(opts["perm"]) if opts.get("perm") is not None else DEFAULT_PERM
+
+    # The serial is stable and may come from the store - that is what keeps a
+    # cached token completely free of HTTP.
+    serial = res.get("serial")
+    firmware = res.get("firmware")
+    if not serial:
+        s, f = _serial_from_store(res["msnr"])
+        serial = s
+        if not firmware:
+            firmware = f
+
+    if not opts.get("force") and serial:
+        have = _store_get_token(serial, user)
+        if have and have.get("token") and _rights_granted(have.get("rights"), perm):
+            return {"ok": 1, "token": have["token"], "validUntil": have["validUntil"],
+                    "rights": have["rights"], "perm": have.get("perm"), "user": user,
+                    "serial": serial, "firmware": firmware, "msnr": res["msnr"]}
+
+    # Without a password nothing can be fetched - check that before bothering
+    # the Miniserver with a single request.
+    password = res.get("password")
+    if password is None or password == "":
+        return _err("nocredentials", "No password available for user %s" % user)
+
+    # From here on a token is really fetched. Unlike the serial the firmware
+    # changes with every Miniserver update, so it is never taken from the store.
+    if res.get("firmware") is None:
+        api = _ms_api(res, **_call_opts(opts))
+        if not api["ok"]:
+            return api
+        serial = api["serial"]
+        firmware = api["firmware"]
+
+    if not _fw_supported(firmware):
+        return _err("fwtooold", "Miniserver firmware %s is below %s - tokens would need "
+                                "application encryption" % (firmware, MIN_FIRMWARE))
+
+    k = _getkey2(res, user, **_call_opts(opts))
+    if not k["ok"]:
+        return k
+
+    pwhash = _pw_hash(password, k["salt"], k["alg"])
+    authhash = _auth_hash(user, pwhash, k["key"], k["alg"])
+    info = opts.get("info") or ("LoxBerry %s" % _lb.lbhostname())
+
+    url = ("%s/jdev/sys/gettoken/%s/%s/%d/%s/%s"
+           % (res["baseurl"], authhash, urllib.parse.quote(str(user), safe=""), perm,
+              _client_uuid(user), urllib.parse.quote(str(info), safe="")))
+
+    code, body, _status = _call(url, **opts)
+    if code is None:
+        return _err("unreachable", "%s did not answer" % res["baseurl"])
+    code = _effective_code(code, body)
+    # A wrong user or password shows up HERE, not at getkey2
+    if code == 401:
+        return _err("badcredentials", "gettoken returned 401 for user %s" % user)
+    if code != 200:
+        return _err("httperror", "gettoken returned %s" % code)
+
+    v = _ll_value(body)
+    if not isinstance(v, dict) or not v.get("token"):
+        return _err("parseerror", "gettoken could not be parsed")
+
+    if not _rights_granted(v.get("tokenRights"), perm):
+        return _err("missingright",
+                    "Miniserver granted rights %s, which does not include the requested "
+                    "permission %d (0x%x)" % (v.get("tokenRights"), perm, perm))
+
+    tokendata = {"token": v["token"], "validUntil": v.get("validUntil"),
+                 "rights": v.get("tokenRights"), "perm": perm,
+                 "acquired": _lb.epoch2lox(), "info": info}
+    _store_put_token(serial, user,
+                     {"msnr": res["msnr"], "name": res["name"],
+                      "is_lbsystem": res["is_lbsystem"], "lbsystem_user": res["lbsystem_user"],
+                      "firmware": firmware, "checked": _lb.epoch2lox()},
+                     tokendata)
+
+    out = dict(tokendata)
+    out.update({"ok": 1, "user": user, "serial": serial, "firmware": firmware,
+                "msnr": res["msnr"]})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# token_info / refresh_token / kill_token / request
+# ---------------------------------------------------------------------------
+def token_info(ms, **opts):
+    res = _resolve_ms_probing(ms, **opts)
+    if not res["ok"]:
+        return res
+
+    serial = res.get("serial")
+    data = _store_read()
+    if not serial:
+        for s in sorted(data.keys()):
+            if str(data[s].get("msnr")) == str(res["msnr"]):
+                serial = s
+                break
+    if not serial:
+        return _err("notoken", "No token stored for Miniserver %s" % ms)
+
+    have = data.get(serial, {}).get("users", {}).get(res["user"])
+    if not have or not have.get("token"):
+        return _err("notoken", "No token stored for user %s" % res["user"])
+
+    return {"ok": 1, "token": have["token"], "validUntil": have["validUntil"],
+            "rights": have.get("rights"), "perm": have.get("perm"), "info": have.get("info"),
+            "user": res["user"], "serial": serial, "msnr": res["msnr"],
+            "firmware": data[serial].get("firmware"),
+            "expires_in": int(have["validUntil"]) - _lb.epoch2lox()}
+
+
+def refresh_token(ms, **opts):
+    """refreshjwt works with token authentication only - no password involved.
+    It answers with a JWT (eyJ0eXAi...) instead of the hex token."""
+    have = token_info(ms, **opts)
+    if not have["ok"]:
+        return have
+    res = _resolve_ms_probing(ms, **opts)
+    if not res["ok"]:
+        return res
+
+    k = _getkey2(res, have["user"], **_call_opts(opts))
+    if not k["ok"]:
+        return k
+    h = _token_hash(have["token"], k["key"], k["alg"])
+
+    # The path carries the token HASH, autht the PLAIN token. Measured on
+    # 17.1.7.3: hashing both consumes the one-time key twice and the Miniserver
+    # answers HTTP 200 with LL.code 401.
+    quoted = urllib.parse.quote(str(have["user"]), safe="")
+    url = "%s/jdev/sys/refreshjwt/%s/%s?autht=%s&user=%s" % (
+        res["baseurl"], h, quoted,
+        urllib.parse.quote(str(have["token"]), safe=""), quoted)
+
+    code, body, _status = _call(url, **opts)
+    if code is None:
+        return _err("unreachable", "%s did not answer" % res["baseurl"])
+    code = _effective_code(code, body)
+    if code == 401:
+        return _err("revoked", "refreshjwt returned 401 - the token was not accepted")
+    if code != 200:
+        return _err("httperror", "refreshjwt returned %s" % code)
+
+    v = _ll_value(body)
+    if not isinstance(v, dict) or not v.get("token"):
+        return _err("parseerror", "refreshjwt could not be parsed")
+
+    tokendata = {"token": v["token"], "validUntil": v.get("validUntil"),
+                 "rights": v.get("tokenRights", have.get("rights")), "perm": have.get("perm"),
+                 "acquired": _lb.epoch2lox(), "info": have.get("info")}
+    _store_put_token(have["serial"], have["user"],
+                     {"msnr": res["msnr"], "checked": _lb.epoch2lox()}, tokendata)
+
+    out = dict(tokendata)
+    out.update({"ok": 1, "user": have["user"], "serial": have["serial"],
+                "firmware": have.get("firmware"), "msnr": res["msnr"]})
+    return out
+
+
+def kill_token(ms, **opts):
+    """Revoking needs the password: killtoken was measured to work with Basic
+    Auth only, not with token authentication."""
+    have = token_info(ms, **opts)
+    if not have["ok"]:
+        return have
+    res = _resolve_ms_probing(ms, **opts)
+    if not res["ok"]:
+        return res
+    if res.get("password") in (None, ""):
+        return _err("nopassword", "kill_token needs the password of user %s" % have["user"])
+
+    k = _getkey2(res, have["user"], **_call_opts(opts))
+    if not k["ok"]:
+        return k
+    h = _token_hash(have["token"], k["key"], k["alg"])
+
+    url = "%s/jdev/sys/killtoken/%s/%s" % (res["baseurl"], h,
+                                           urllib.parse.quote(str(have["user"]), safe=""))
+    callopts = dict(opts)
+    callopts["basicauth_user"] = have["user"]
+    callopts["basicauth_password"] = res["password"]
+
+    code, body, _status = _call(url, **callopts)
+    if code is None:
+        return _err("unreachable", "%s did not answer" % res["baseurl"])
+    code = _effective_code(code, body)
+    if code == 401:
+        return _err("badcredentials", "killtoken returned 401")
+    if code != 200:
+        return _err("httperror", "killtoken returned %s" % code)
+
+    _store_del_token(have["serial"], have["user"])
+    return {"ok": 1, "user": have["user"], "serial": have["serial"]}
+
+
+def _sign_url(baseurl, command, token, user, res, **opts):
+    k = _getkey2(res, user, **_call_opts(opts))
+    if not k["ok"]:
+        return (None, k)
+    h = _token_hash(token, k["key"], k["alg"])
+    sep = "&" if "?" in command else "?"
+    return ("%s%s%sautht=%s&user=%s"
+            % (baseurl, command, sep, h, urllib.parse.quote(str(user), safe="")), None)
+
+
+def request(ms, command, **opts):
+    """Runs a Miniserver command with token authentication.
+    Returns (content, info) - same keys as loxberry.io.mshttp_call2, plus
+    errcode carrying the error code of this lib."""
+    info = {"code": None, "status": None, "error": 1, "message": "", "errcode": None}
+
+    tok = get_token(ms, **opts)
+    if not tok["ok"]:
+        info["errcode"] = tok["error"]
+        info["message"] = tok["message"]
+        return (None, info)
+
+    left = int(tok["validUntil"]) - _lb.epoch2lox()
+    if left <= 0:
+        forced = dict(opts)
+        forced["force"] = 1
+        tok = get_token(ms, **forced)
+    elif left < REFRESH_THRESHOLD:
+        r = refresh_token(ms, **opts)
+        if r["ok"]:
+            tok = r
+    if not tok["ok"]:
+        info["errcode"] = tok["error"]
+        info["message"] = tok["message"]
+        return (None, info)
+
+    res = _resolve_ms_probing(ms, **opts)
+    if not res["ok"]:
+        info["errcode"] = res["error"]
+        info["message"] = res["message"]
+        return (None, info)
+
+    for attempt in (1, 2):
+        url, urlerr = _sign_url(res["baseurl"], command, tok["token"], tok["user"], res, **_call_opts(opts))
+        if not url:
+            info["errcode"] = urlerr["error"]
+            info["message"] = urlerr["message"]
+            return (None, info)
+
+        code, body, status = _call(url, **opts)
+        if code is None:
+            info["errcode"] = "unreachable"
+            info["message"] = "%s did not answer" % res["baseurl"]
+            return (None, info)
+
+        code = _effective_code(code, body)
+        info["code"] = code
+        info["status"] = status
+
+        if code == 401:
+            # The token may be gone on the Miniserver although validUntil still
+            # looks fine. Fetch a new one and retry ONCE.
+            if attempt == 1:
+                forced = dict(opts)
+                forced["force"] = 1
+                fresh = get_token(ms, **forced)
+                if fresh["ok"]:
+                    tok = fresh
+                    continue
+                info["errcode"] = fresh["error"]
+                info["message"] = fresh["message"]
+                return (None, info)
+            info["errcode"] = "revoked"
+            info["message"] = "%s returned 401 twice - the token was revoked" % command
+            return (None, info)
+
+        if code < 200 or code >= 300:
+            info["errcode"] = "httperror"
+            info["message"] = "%s FAILED - Error %s" % (command, code)
+            return (None, info)
+
+        info["error"] = 0
+        info["message"] = "Request ok"
+        return (body, info)

--- a/libs/pythonlib/testing/libcompare.py
+++ b/libs/pythonlib/testing/libcompare.py
@@ -131,4 +131,57 @@ emit("iso_languages_values_avail", lbweb.iso_languages(onlyavail=True, selection
 emit("get_netservers", lbstorage.get_netservers())
 emit("get_usbstorage", lbstorage.get_usbstorage(""))
 
+# --- loxberry.auth (pure functions) ---
+from loxberry import auth as lbauth
+
+_auth_key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+_auth_apiv = ("{'snr': 'AB:CD:EF:01:02:03', 'version':'17.1.7.3', 'hasEventSlots':true, "
+              "'isInTrust':false, 'local':true,'certTLD':'com'}")
+
+emit("auth_norm_alg", [lbauth._norm_alg(a) for a in ("SHA256", "sha-256", "SHA1", "", "MD5")])
+
+_auth_pw256 = lbauth._pw_hash("Test1234", "41B0A8F1", "SHA256")
+_auth_pw1 = lbauth._pw_hash("Test1234", "41B0A8F1", "SHA1")
+emit("auth_hashes", {
+    "pw_sha256": _auth_pw256,
+    "pw_sha1": _auth_pw1,
+    "auth_sha256": lbauth._auth_hash("loxberry", _auth_pw256, _auth_key, "SHA256"),
+    "auth_sha1": lbauth._auth_hash("loxberry", _auth_pw1, _auth_key, "SHA1"),
+    "token_sha256": lbauth._token_hash("a1b2c3d4e5f60718293a4b5c6d7e8f90", _auth_key, "SHA256"),
+    "token_sha1": lbauth._token_hash("a1b2c3d4e5f60718293a4b5c6d7e8f90", _auth_key, "SHA1"),
+})
+
+emit("auth_parse_api_value", lbauth._parse_api_value(_auth_apiv))
+
+emit("auth_fw_supported", [lbauth._fw_supported(f) for f in
+                           ("17.1.7.3", "11.2.10.22", "11.2.10.21", "11.2.9.99", "12.0", "")])
+
+emit("auth_rights_granted", [
+    lbauth._rights_granted(1924, 0x100),
+    lbauth._rights_granted(1924, 0x04),
+    lbauth._rights_granted(4, 0x100),
+    lbauth._rights_granted(1924, 0x104),
+])
+
+emit("auth_ll_codes", [
+    lbauth._ll_code('{"LL":{"value":{},"code":"401"}}'),
+    lbauth._ll_code('{"LL":{"value":"x","Code":"200"}}'),
+    lbauth._ll_code("<html>401</html>"),
+    lbauth._effective_code(200, '{"LL":{"value":{},"code":"401"}}'),
+    lbauth._effective_code(200, '{"LL":{"value":"x","Code":"200"}}'),
+    lbauth._effective_code(401, "<html>401</html>"),
+])
+
+emit("auth_constants", {
+    "default_perm": lbauth.DEFAULT_PERM,
+    "refresh_threshold": lbauth.REFRESH_THRESHOLD,
+    "min_firmware": lbauth.MIN_FIRMWARE,
+    "perm_app": lbauth.PERM_APP,
+    "perm_sysws": lbauth.PERM_SYSWS,
+})
+
+_auth_ms = lb.get_miniservers() or {}
+emit("auth_ms_baseurl", lbauth._ms_baseurl(_auth_ms.get("1")) if _auth_ms.get("1") else None)
+emit("auth_auth_method_ms1", lbauth.auth_method(1))
+
 sys.exit(0)

--- a/libs/pythonlib/testing/test_auth_unit.py
+++ b/libs/pythonlib/testing/test_auth_unit.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+test_auth_unit.py - offline unit tests for loxberry/auth.py.
+No Miniserver needed; the transport hook is replaced by a fake.
+
+    python3 test_auth_unit.py
+
+Sets its own LBHOMEDIR below a temp dir, so the productive installation is
+never touched.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+_HOME = tempfile.mkdtemp(prefix="authtest_")
+os.environ["LBHOMEDIR"] = _HOME
+os.makedirs(os.path.join(_HOME, "config", "system"), exist_ok=True)
+os.makedirs(os.path.join(_HOME, "data", "system"), exist_ok=True)
+
+GENERAL_JSON = """{
+  "Base": { "Lang": "de", "Version": "4.0.0.15" },
+  "Miniserver": {
+    "1": {
+      "Name": "Miniserver", "Ipaddress": "192.0.2.10",
+      "Admin": "loxberry", "Pass": "TestPass%2123",
+      "Admin_raw": "loxberry", "Pass_raw": "TestPass!23",
+      "Credentials_raw": "loxberry:TestPass!23",
+      "Port": 80, "Porthttps": 443, "Preferhttps": 0
+    },
+    "2": {
+      "Name": "MS Secure", "Ipaddress": "192.0.2.11",
+      "Admin": "admin", "Pass": "secret",
+      "Admin_raw": "admin", "Pass_raw": "secret",
+      "Credentials_raw": "admin:secret",
+      "Port": 80, "Porthttps": 4443, "Preferhttps": 1,
+      "Authmethod": "token"
+    },
+    "3": {
+      "Name": "MS IPv6", "Ipaddress": "fe80::1",
+      "Admin": "admin", "Pass": "secret",
+      "Admin_raw": "admin", "Pass_raw": "secret",
+      "Credentials_raw": "admin:secret",
+      "Port": 80, "Porthttps": 443, "Preferhttps": 0,
+      "Authmethod": "basicauth"
+    }
+  }
+}
+"""
+with open(os.path.join(_HOME, "config", "system", "general.json"), "w", encoding="utf-8") as _fh:
+    _fh.write(GENERAL_JSON)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from loxberry import auth
+from loxberry import system as _lbsys
+
+KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+STORE = os.path.join(_HOME, "data", "system", "tokens.json")
+
+
+class TestPure(unittest.TestCase):
+    def test_norm_alg(self):
+        self.assertEqual(auth._norm_alg("SHA256"), "SHA256")
+        self.assertEqual(auth._norm_alg("sha-256"), "SHA256")
+        self.assertEqual(auth._norm_alg("SHA1"), "SHA1")
+        self.assertEqual(auth._norm_alg(None), "SHA1")
+        self.assertIsNone(auth._norm_alg("MD5"))
+
+    def test_hash_chain_sha256(self):
+        pw = auth._pw_hash("Test1234", "41B0A8F1", "SHA256")
+        self.assertEqual(pw, "3E4A5D209675FD7633320D7F1AA5B399174D2B397ABE4FE53118FCECE38A847D")
+        self.assertEqual(auth._auth_hash("loxberry", pw, KEY, "SHA256"),
+                         "31db6348ae60d52f53381bc3ebf2b7b1691a55e51110ef31ac50b19b1b2f9f47")
+        self.assertEqual(auth._token_hash("a1b2c3d4e5f60718293a4b5c6d7e8f90", KEY, "SHA256"),
+                         "7c75d4ea7111e124200e9939ded8f9d2ece6835089a4d5ff1fb6d96e57b6dd65")
+
+    def test_hash_chain_sha1(self):
+        pw = auth._pw_hash("Test1234", "41B0A8F1", "SHA1")
+        self.assertEqual(pw, "3A09820F277977B59FE88D032BBC7ECF5C2C7BCD")
+        self.assertEqual(auth._auth_hash("loxberry", pw, KEY, "SHA1"),
+                         "dde0f27175043736346411f693364a2bee2c0308")
+        self.assertEqual(auth._token_hash("a1b2c3d4e5f60718293a4b5c6d7e8f90", KEY, "SHA1"),
+                         "9135606ae0eac2862b8536f0adc059cf57fd7e62")
+
+    def test_parse_api_value(self):
+        # jdev/cfg/api returns value as a STRING with single quotes - not JSON
+        val = ("{'snr': 'AB:CD:EF:01:02:03', 'version':'17.1.7.3', 'hasEventSlots':true, "
+               "'isInTrust':false, 'local':true,'certTLD':'com'}")
+        api = auth._parse_api_value(val)
+        self.assertEqual(api["snr"], "AB:CD:EF:01:02:03")
+        self.assertEqual(api["version"], "17.1.7.3")
+        self.assertEqual(api["certTLD"], "com")
+        self.assertEqual(api["local"], "true")
+        self.assertIsNone(auth._parse_api_value(""))
+        self.assertIsNone(auth._parse_api_value(None))
+
+    def test_fw_supported(self):
+        self.assertEqual(auth._fw_supported("17.1.7.3"), 1)
+        self.assertEqual(auth._fw_supported("11.2.10.22"), 1)
+        self.assertEqual(auth._fw_supported("11.2.10.21"), 0)
+        self.assertEqual(auth._fw_supported("11.2.9.99"), 0)
+        self.assertEqual(auth._fw_supported("12.0"), 1)
+        self.assertEqual(auth._fw_supported(""), 0)
+
+    def test_rights_granted(self):
+        # perm 0x104 was measured to return tokenRights 1924 = 4+128+256+512+1024
+        self.assertEqual(auth._rights_granted(1924, auth.PERM_SYSWS), 1)
+        self.assertEqual(auth._rights_granted(1924, auth.PERM_APP), 1)
+        self.assertEqual(auth._rights_granted(4, auth.PERM_SYSWS), 0)
+        self.assertEqual(auth._rights_granted(1924, 0x104), 1)
+
+    def test_constants(self):
+        self.assertEqual(auth.DEFAULT_PERM, 0x104)
+        self.assertEqual(auth.REFRESH_THRESHOLD, 7 * 86400)
+        self.assertEqual(auth.MIN_FIRMWARE, "11.2.10.22")
+
+
+class TestStore(unittest.TestCase):
+    def setUp(self):
+        auth.store_file = STORE
+        # the process cache outlives the file - clear it or a previous test's
+        # token answers here
+        auth._cache_clear()
+        if os.path.exists(STORE):
+            os.unlink(STORE)
+
+    def test_read_without_file(self):
+        self.assertEqual(auth._store_file(), STORE)
+        self.assertEqual(auth._store_read(), {})
+        self.assertFalse(os.path.exists(STORE))
+        self.assertIsNone(auth._store_get_token("AB:CD:EF:01:02:03", "loxberry"))
+
+    def test_put_get_del(self):
+        msmeta = {"msnr": "1", "name": "Miniserver", "is_lbsystem": True,
+                  "lbsystem_user": "loxberry", "firmware": "17.1.7.3", "checked": 556606212}
+        tok = {"token": "abc123", "validUntil": 564559554, "rights": 1924,
+               "perm": 260, "acquired": 556606212, "info": "LoxBerry testhost"}
+
+        self.assertEqual(auth._store_put_token("AB:CD:EF:01:02:03", "loxberry", msmeta, tok), 1)
+        self.assertTrue(os.path.exists(STORE))
+        if os.name == "posix":
+            self.assertEqual(os.stat(STORE).st_mode & 0o777, 0o600)
+
+        got = auth._store_get_token("AB:CD:EF:01:02:03", "loxberry")
+        self.assertEqual(got["token"], "abc123")
+        self.assertEqual(got["validUntil"], 564559554)
+
+        with open(STORE, encoding="utf-8") as fh:
+            raw = json.load(fh)
+        self.assertEqual(raw["AB:CD:EF:01:02:03"]["name"], "Miniserver")
+        self.assertEqual(raw["AB:CD:EF:01:02:03"]["firmware"], "17.1.7.3")
+        self.assertIn("loxberry", raw["AB:CD:EF:01:02:03"]["users"])
+        self.assertNotIn("password", raw["AB:CD:EF:01:02:03"]["users"]["loxberry"])
+        self.assertNotIn("key", raw["AB:CD:EF:01:02:03"]["users"]["loxberry"])
+
+        # unchanged content must not touch the file - the store is on the SD card
+        mtime = os.stat(STORE).st_mtime
+        time.sleep(1)
+        self.assertEqual(auth._store_put_token("AB:CD:EF:01:02:03", "loxberry", msmeta, tok), 0)
+        self.assertEqual(os.stat(STORE).st_mtime, mtime)
+
+        tok2 = dict(tok, token="def456")
+        self.assertEqual(auth._store_put_token("AB:CD:EF:01:02:03", "loxberry", msmeta, tok2), 1)
+        self.assertEqual(auth._store_get_token("AB:CD:EF:01:02:03", "loxberry")["token"], "def456")
+
+        auth._store_put_token("AB:CD:EF:01:02:03", "sortmgr", msmeta, tok)
+        self.assertEqual(auth._store_get_token("AB:CD:EF:01:02:03", "sortmgr")["token"], "abc123")
+        self.assertEqual(auth._store_get_token("AB:CD:EF:01:02:03", "loxberry")["token"], "def456")
+
+        self.assertEqual(auth._store_del_token("AB:CD:EF:01:02:03", "sortmgr"), 1)
+        self.assertIsNone(auth._store_get_token("AB:CD:EF:01:02:03", "sortmgr"))
+        self.assertEqual(auth._store_del_token("AB:CD:EF:01:02:03", "sortmgr"), 0)
+
+    def test_broken_file(self):
+        with open(STORE, "w", encoding="utf-8") as fh:
+            fh.write("{ das ist kein json")
+        self.assertEqual(auth._store_read(), {})
+
+
+class TestResolve(unittest.TestCase):
+    def setUp(self):
+        auth.store_file = STORE
+        # the process cache outlives the file - clear it or a previous test's
+        # token answers here
+        auth._cache_clear()
+        if os.path.exists(STORE):
+            os.unlink(STORE)
+
+    def test_err(self):
+        e = auth._err("unreachable", "timed out")
+        self.assertEqual(e["ok"], 0)
+        self.assertEqual(e["error"], "unreachable")
+        self.assertEqual(e["message"], "timed out")
+
+    def test_by_number(self):
+        r = auth._resolve_ms(1)
+        self.assertEqual(r["ok"], 1)
+        self.assertEqual(r["msnr"], "1")
+        self.assertEqual(r["name"], "Miniserver")
+        self.assertEqual(r["baseurl"], "http://192.0.2.10:80")
+        self.assertEqual(r["user"], "loxberry")
+        # the plaintext password comes from Pass_raw, never from the escaped Pass
+        self.assertEqual(r["password"], "TestPass!23")
+        self.assertEqual(auth._resolve_ms(2)["baseurl"], "https://192.0.2.11:4443")
+        self.assertEqual(auth._resolve_ms(3)["baseurl"], "http://[fe80::1]:80")
+
+    def test_user_option(self):
+        r = auth._resolve_ms(1, user="sortmgr", password="geheim")
+        self.assertEqual(r["user"], "sortmgr")
+        self.assertEqual(r["password"], "geheim")
+        # a foreign user must never inherit the password from general.json
+        self.assertIsNone(auth._resolve_ms(1, user="sortmgr")["password"])
+
+    def test_not_found(self):
+        self.assertEqual(auth._resolve_ms(9)["error"], "msnotfound")
+        self.assertEqual(auth._resolve_ms(None)["error"], "msnotfound")
+        self.assertEqual(auth._resolve_ms("")["error"], "msnotfound")
+        self.assertEqual(auth._resolve_ms("AB:CD:EF:01:02:03")["error"], "msnotfound")
+
+    def test_by_serial(self):
+        auth._store_put_token("AB:CD:EF:01:02:03", "loxberry",
+                              {"msnr": "1", "name": "Miniserver", "firmware": "17.1.7.3"},
+                              {"token": "abc", "validUntil": 1, "rights": 1924})
+        r = auth._resolve_ms("AB:CD:EF:01:02:03")
+        self.assertEqual(r["ok"], 1)
+        self.assertEqual(r["msnr"], "1")
+        self.assertEqual(r["serial"], "AB:CD:EF:01:02:03")
+        self.assertEqual(auth._resolve_ms("ab:cd:ef:01:02:03")["msnr"], "1")
+
+    def test_auth_method(self):
+        auth._store_put_token("AB:CD:EF:01:02:03", "loxberry", {"msnr": "1"},
+                              {"token": "abc", "validUntil": 1, "rights": 1924})
+        self.assertEqual(auth.auth_method(1), "basicauth")
+        self.assertEqual(auth.auth_method(2), "token")
+        self.assertEqual(auth.auth_method(3), "basicauth")
+        self.assertEqual(auth.auth_method(9), "basicauth")
+        self.assertEqual(auth.auth_method("AB:CD:EF:01:02:03"), "basicauth")
+
+
+
+KEY2 = KEY
+TOKHASH = "3b50109633af4140485302f72bd8a2734950286ca29a4633ef6c54376540bd69"
+AUTHHASH = "6811aac909afa7d530fd1cf87a28e4a9db15ad4e99eea57b33944319b05a86c5"
+
+
+class FakeMiniserver(object):
+    """Replaces auth.transport. Records every URL and every option dict."""
+
+    def __init__(self):
+        self.calls = []
+        self.optlog = []
+        self.api_fw = "17.1.7.3"
+        self.api_serial = "AB:CD:EF:01:02:03"
+        self.gettoken = "ok"          # ok | 401 | unreachable
+        self.rights = 1924
+        self.validUntil = 999999999
+        self.unreachable_all = False
+        self.refresh = "ok"           # ok | 401 | ll401
+        self.kill = "ok"              # ok | 401
+        self.cmd_401_once = 0
+
+    def __call__(self, url, **opts):
+        self.calls.append(url)
+        self.optlog.append((url, dict(opts)))
+        if self.unreachable_all:
+            return (None, None, "Connection refused")
+
+        if url.endswith("/jdev/cfg/api"):
+            v = ("{'snr': '%s', 'version':'%s', 'hasEventSlots':true, "
+                 "'isInTrust':false, 'local':true,'certTLD':'com'}" % (self.api_serial, self.api_fw))
+            return (200, '{"LL": { "control": "dev/cfg/api", "value": "%s", "Code": "200"}}' % v, "200 OK")
+
+        if "/jdev/sys/getkey2/" in url:
+            return (200, '{"LL":{"control":"dev/sys/getkey2","code":"200","value":'
+                         '{"key":"%s","salt":"41B0A8F1","hashAlg":"SHA256"}}}' % KEY2, "200 OK")
+
+        if "/jdev/sys/gettoken/" in url:
+            if self.gettoken == "unreachable":
+                return (None, None, "Connection refused")
+            if self.gettoken == "401":
+                return (401, "<html><body>401</body></html>", "401 Unauthorized")
+            return (200, '{"LL":{"control":"dev/sys/gettoken","code":"200","value":'
+                         '{"token":"tokTESTVALUE123","key":"%s","validUntil":%d,'
+                         '"tokenRights":%d,"unsecurePass":false}}}'
+                         % (KEY2, self.validUntil, self.rights), "200 OK")
+
+        if "/jdev/sys/refreshjwt/" in url:
+            if self.refresh == "401":
+                return (401, "<html>401</html>", "401 Unauthorized")
+            if self.refresh == "ll401":
+                # measured on the real Miniserver: HTTP 200 with LL.code 401
+                return (200, '{"LL":{"control":"dev/sys/refreshjwt","value":{},"code":"401"}}', "200 OK")
+            return (200, '{"LL":{"control":"dev/sys/refreshjwt","code":"200","value":'
+                         '{"token":"eyJ0eXAiTESTJWT","validUntil":%d,"tokenRights":1924,'
+                         '"unsecurePass":false}}}' % self.validUntil, "200 OK")
+
+        if "/jdev/sys/killtoken/" in url:
+            if self.kill == "401":
+                return (401, "<html>401</html>", "401 Unauthorized")
+            return (200, '{"LL":{"control":"dev/sys/killtoken","code":"200","value":"1"}}', "200 OK")
+
+        if "autht=" in url:
+            if self.cmd_401_once > 0:
+                self.cmd_401_once -= 1
+                return (401, "<html>401</html>", "401 Unauthorized")
+            return (200, '{"LL":{"control":"dev/sps/io/Test","code":"200","value":"42"}}', "200 OK")
+
+        return (404, "not found", "404 Not Found")
+
+
+class TestFlows(unittest.TestCase):
+    def setUp(self):
+        auth.store_file = STORE
+        # the process cache outlives the file - clear it or a previous test's
+        # token answers here
+        auth._cache_clear()
+        if os.path.exists(STORE):
+            os.unlink(STORE)
+        self.ms = FakeMiniserver()
+        auth.transport = self.ms
+
+    def tearDown(self):
+        auth.transport = None
+
+    def _urls(self, needle):
+        return [u for u in self.ms.calls if needle in u]
+
+    def _seed(self, validUntil_offset=60 * 86400, token="tokTESTVALUE123"):
+        auth._store_put_token("AB:CD:EF:01:02:03", "loxberry",
+                              {"msnr": "1", "name": "Miniserver", "firmware": "17.1.7.3"},
+                              {"token": token,
+                               "validUntil": _lbsys.epoch2lox() + validUntil_offset,
+                               "rights": 1924, "perm": 260, "acquired": 1, "info": "x"})
+
+    def test_ll_value(self):
+        self.assertEqual(auth._ll_value('{"LL":{"value":{"a":1},"Code":"200"}}')["a"], 1)
+        self.assertEqual(auth._ll_value('{"LL":{"value":"text","Code":"200"}}'), "text")
+        self.assertIsNone(auth._ll_value("<html>kaputt</html>"))
+        self.assertIsNone(auth._ll_value(""))
+
+    def test_ll_code_and_effective_code(self):
+        self.assertEqual(auth._ll_code('{"LL":{"value":{},"code":"401"}}'), 401)
+        self.assertEqual(auth._ll_code('{"LL":{"value":"x","Code":"200"}}'), 200)
+        self.assertIsNone(auth._ll_code("<html>401</html>"))
+        # an HTTP 200 carrying LL.code 401 is a failure
+        self.assertEqual(auth._effective_code(200, '{"LL":{"value":{},"code":"401"}}'), 401)
+        self.assertEqual(auth._effective_code(200, '{"LL":{"value":"x","Code":"200"}}'), 200)
+        self.assertEqual(auth._effective_code(401, "<html>401</html>"), 401)
+
+    def test_client_uuid(self):
+        u = auth._client_uuid("loxberry")
+        self.assertRegex(u, r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+        self.assertEqual(auth._client_uuid("loxberry"), u)
+        self.assertNotEqual(auth._client_uuid("sortmgr"), u)
+
+    def test_ms_api(self):
+        api = auth._ms_api(auth._resolve_ms(1))
+        self.assertEqual(api["ok"], 1)
+        self.assertEqual(api["serial"], "AB:CD:EF:01:02:03")
+        self.assertEqual(api["firmware"], "17.1.7.3")
+
+    def test_get_token_happy(self):
+        t = auth.get_token(1)
+        self.assertEqual(t["ok"], 1)
+        self.assertEqual(t["token"], "tokTESTVALUE123")
+        self.assertEqual(t["validUntil"], 999999999)
+        self.assertEqual(t["rights"], 1924)
+        self.assertEqual(t["perm"], 260)          # 0x104
+        self.assertEqual(t["user"], "loxberry")
+        self.assertEqual(t["serial"], "AB:CD:EF:01:02:03")
+        self.assertEqual(t["firmware"], "17.1.7.3")
+
+        url = self._urls("/jdev/sys/gettoken/")[0]
+        self.assertIn("/jdev/sys/gettoken/%s/loxberry/260/" % AUTHHASH, url)
+
+        stored = auth._store_get_token("AB:CD:EF:01:02:03", "loxberry")
+        self.assertEqual(stored["token"], "tokTESTVALUE123")
+        self.assertNotIn("key", stored)
+        self.assertNotIn("password", stored)
+
+    def test_get_token_uses_store(self):
+        auth.get_token(1)
+        self.ms.calls = []
+        t = auth.get_token(1)
+        self.assertEqual(t["token"], "tokTESTVALUE123")
+        self.assertEqual(len(self.ms.calls), 0)
+
+        auth.get_token(1, force=1)
+        self.assertGreaterEqual(len(self.ms.calls), 2)
+
+    def test_get_token_by_serial(self):
+        auth.get_token(1)
+        self.assertEqual(auth.get_token("AB:CD:EF:01:02:03")["ok"], 1)
+
+    def test_missing_right(self):
+        self.ms.rights = 4          # App only, no Sys-WS
+        r = auth.get_token(1, force=1)
+        self.assertEqual(r["error"], "missingright")
+
+    def test_bad_credentials(self):
+        # the 401 arrives at gettoken - getkey2 answers 200 even for an
+        # unknown user
+        self.ms.gettoken = "401"
+        self.assertEqual(auth.get_token(1, force=1)["error"], "badcredentials")
+
+    def test_firmware_too_old(self):
+        self.ms.api_fw = "11.2.10.21"
+        r = auth.get_token(1, force=1)
+        self.assertEqual(r["error"], "fwtooold")
+        self.assertEqual(len(self._urls("/jdev/sys/")), 0)
+
+    def test_unreachable(self):
+        self.ms.unreachable_all = True
+        self.assertEqual(auth.get_token(1, force=1)["error"], "unreachable")
+
+    def test_no_credentials(self):
+        r = auth.get_token(1, user="sortmgr")
+        self.assertEqual(r["error"], "nocredentials")
+        self.assertEqual(len(self.ms.calls), 0)
+
+    def test_foreign_user(self):
+        t = auth.get_token(1, user="sortmgr", password="geheim", perm=0x04)
+        self.assertEqual(t["ok"], 1)
+        self.assertEqual(t["perm"], 4)
+        self.assertEqual(t["user"], "sortmgr")
+        self.assertEqual(auth._store_get_token("AB:CD:EF:01:02:03", "sortmgr")["token"],
+                         "tokTESTVALUE123")
+
+    def test_token_info(self):
+        self._seed()
+        ti = auth.token_info(1)
+        self.assertEqual(ti["ok"], 1)
+        self.assertEqual(ti["token"], "tokTESTVALUE123")
+        self.assertEqual(ti["serial"], "AB:CD:EF:01:02:03")
+        self.assertGreater(ti["expires_in"], 59 * 86400)
+        self.assertEqual(auth.token_info(1, user="niemand")["error"], "notoken")
+
+    def test_request_happy(self):
+        self._seed()
+        content, info = auth.request(1, "/jdev/sps/io/Test")
+        self.assertEqual(info["code"], 200)
+        self.assertEqual(info["error"], 0)
+        self.assertIn('"value":"42"', content)
+        url = self._urls("/jdev/sps/io/Test")[0]
+        self.assertTrue(url.endswith("?autht=%s&user=loxberry" % TOKHASH))
+        # the one-time key is fetched again for every signed request
+        self.ms.calls = []
+        auth.request(1, "/jdev/sps/io/Test")
+        self.assertEqual(len(self._urls("/jdev/sys/getkey2/")), 1)
+
+    def test_request_existing_query(self):
+        self._seed()
+        auth.request(1, "/jdev/sps/io/Test?state=on")
+        self.assertIn("?state=on&autht=", self._urls("/jdev/sps/io/Test")[0])
+
+    def test_request_retries_once_on_401(self):
+        self._seed()
+        self.ms.cmd_401_once = 1
+        content, info = auth.request(1, "/jdev/sps/io/Test")
+        self.assertEqual(info["error"], 0)
+        self.assertEqual(len(self._urls("/jdev/sys/gettoken/")), 1)
+
+    def test_request_revoked_on_second_401(self):
+        self._seed()
+        self.ms.cmd_401_once = 2
+        content, info = auth.request(1, "/jdev/sps/io/Test")
+        self.assertEqual(info["errcode"], "revoked")
+        self.assertIsNone(content)
+
+    def test_expired_token_is_refetched(self):
+        self._seed(validUntil_offset=-10)
+        auth.request(1, "/jdev/sps/io/Test")
+        self.assertEqual(len(self._urls("/jdev/sys/gettoken/")), 1)
+        self.assertEqual(len(self._urls("/jdev/sys/refreshjwt/")), 0)
+
+    def test_token_below_threshold_is_renewed(self):
+        self._seed(validUntil_offset=3 * 86400)
+        auth.request(1, "/jdev/sps/io/Test")
+        self.assertEqual(len(self._urls("/jdev/sys/refreshjwt/")), 1)
+        self.assertEqual(len(self._urls("/jdev/sys/gettoken/")), 0)
+        self.assertEqual(auth._store_get_token("AB:CD:EF:01:02:03", "loxberry")["token"],
+                         "eyJ0eXAiTESTJWT")
+
+    def test_refresh_token(self):
+        self._seed()
+        r = auth.refresh_token(1)
+        self.assertEqual(r["ok"], 1)
+        self.assertEqual(r["token"], "eyJ0eXAiTESTJWT")
+        self.assertEqual(auth.refresh_token(1, user="niemand")["error"], "notoken")
+
+    def test_refresh_uses_plain_token_in_autht(self):
+        self._seed()
+        auth.refresh_token(1)
+        url = self._urls("/jdev/sys/refreshjwt/")[0]
+        self.assertRegex(url, r"/jdev/sys/refreshjwt/[0-9a-f]{64}/loxberry\?autht=")
+        self.assertIn("autht=tokTESTVALUE123&", url)
+
+    def test_refresh_rejected(self):
+        self._seed()
+        self.ms.refresh = "401"
+        self.assertEqual(auth.refresh_token(1)["error"], "revoked")
+        self.ms.refresh = "ll401"
+        self.assertEqual(auth.refresh_token(1)["error"], "revoked")
+
+    def test_kill_token(self):
+        self._seed()
+        self.assertEqual(auth.kill_token(1, user="sortmgr")["error"], "notoken")
+        k = auth.kill_token(1)
+        self.assertEqual(k["ok"], 1)
+        killopts = [o for u, o in self.ms.optlog if "/jdev/sys/killtoken/" in u][0]
+        self.assertEqual(killopts["basicauth_user"], "loxberry")
+        self.assertEqual(killopts["basicauth_password"], "TestPass!23")
+        self.assertIsNone(auth._store_get_token("AB:CD:EF:01:02:03", "loxberry"))
+
+
+class TestProcessCache(unittest.TestCase):
+    def setUp(self):
+        auth.store_file = STORE
+        auth._cache_clear()
+        if os.path.exists(STORE):
+            os.unlink(STORE)
+
+    def test_cache(self):
+        auth._store_put_token("AA:BB:CC:DD:EE:FF", "cacheuser", {"msnr": "1"},
+                              {"token": "cached1", "validUntil": 5, "rights": 1924})
+        # pull the file away underneath the process - the cache must still answer
+        os.unlink(STORE)
+        self.assertEqual(
+            auth._store_get_token("AA:BB:CC:DD:EE:FF", "cacheuser")["token"], "cached1")
+
+        auth._cache_clear()
+        self.assertIsNone(auth._store_get_token("AA:BB:CC:DD:EE:FF", "cacheuser"))
+
+        auth._store_put_token("AA:BB:CC:DD:EE:FF", "cacheuser", {"msnr": "1"},
+                              {"token": "cached2", "validUntil": 5, "rights": 1924})
+        self.assertEqual(
+            auth._store_get_token("AA:BB:CC:DD:EE:FF", "cacheuser")["token"], "cached2")
+
+        auth._store_del_token("AA:BB:CC:DD:EE:FF", "cacheuser")
+        self.assertIsNone(auth._store_get_token("AA:BB:CC:DD:EE:FF", "cacheuser"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/libs/pythonlib/testing/testauth.py
+++ b/libs/pythonlib/testing/testauth.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+testauth.py - loxberry/auth.py against a real Miniserver.
+Runs on a live LoxBerry. Analogous to the Perl and PHP scripts.
+
+    python3 testauth.py [msnr|serial] [--store PATH] [--keep]
+
+Without --store the token is kept in /tmp so the productive
+data/system/tokens.json is not touched. Without --keep the token is revoked at
+the end - the Miniserver must not collect orphans in its token list.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from loxberry import auth
+from loxberry import system as lb
+
+args = sys.argv[1:]
+ms = args.pop(0) if args and not args[0].startswith("--") else 1
+keep = False
+store = "/tmp/testauth_tokens_py.json"
+while args:
+    a = args.pop(0)
+    if a == "--keep":
+        keep = True
+    elif a == "--store" and args:
+        store = args.pop(0)
+
+auth.store_file = store
+
+print("Miniserver : %s" % ms)
+print("Token store: %s" % store)
+print("auth_method: %s" % auth.auth_method(ms))
+
+failed = 0
+
+
+def step(name, res):
+    global failed
+    if isinstance(res, dict) and res.get("ok"):
+        print("OK   %s" % name)
+        return True
+    failed += 1
+    print("FAIL %s: %s - %s" % (name, res.get("error"), res.get("message")))
+    return False
+
+
+print("\n=== get_token ===")
+t = auth.get_token(ms, info="LoxBerry Auth selftest Python", force=1)
+if step("get_token", t):
+    print("     serial     : %s" % t["serial"])
+    print("     firmware   : %s" % t["firmware"])
+    print("     perm       : %d (0x%x)" % (t["perm"], t["perm"]))
+    print("     rights     : %d" % t["rights"])
+    print("     validUntil : %d (lox) = %s"
+          % (t["validUntil"], time.strftime("%Y-%m-%d %H:%M:%S",
+                                            time.localtime(lb.lox2epoch(t["validUntil"])))))
+    days = (t["validUntil"] - lb.epoch2lox()) / 86400.0
+    print("     lifetime   : %.1f days%s"
+          % (days, " (matches the ~3 months measured for 0x104)" if days > 80
+             else " (SHORTER THAN EXPECTED)"))
+    print("     Sys-WS bit : %s"
+          % ("granted - reboot would be allowed"
+             if auth._rights_granted(t["rights"], auth.PERM_SYSWS) else "MISSING"))
+
+print("\n=== token_info ===")
+ti = auth.token_info(ms)
+if step("token_info", ti):
+    print("     expires_in : %d s" % ti["expires_in"])
+
+print("\n=== request /jdev/cfg/version ===")
+content, info = auth.request(ms, "/jdev/cfg/version")
+if info["error"] == 0:
+    print("OK   request (code %s)" % info["code"])
+    print("     %s" % content)
+else:
+    failed += 1
+    print("FAIL request: %s - %s" % (info["errcode"], info["message"]))
+
+print("\n=== second request: the one-time key must be fetched again ===")
+_c2, i2 = auth.request(ms, "/jdev/cfg/version")
+if i2["error"] == 0:
+    print("OK   second request (code %s)" % i2["code"])
+else:
+    failed += 1
+    print("FAIL second request: %s - %s" % (i2["errcode"], i2["message"]))
+
+print("\n=== refresh_token (password free) ===")
+rt = auth.refresh_token(ms)
+if step("refresh_token", rt):
+    print("     token      : %s..." % rt["token"][:12])
+    print("     format     : %s" % ("JWT" if rt["token"].startswith("eyJ") else "hex"))
+
+print("\n=== request with the refreshed token ===")
+_c3, i3 = auth.request(ms, "/jdev/cfg/version")
+if i3["error"] == 0:
+    print("OK   request after refresh (code %s)" % i3["code"])
+else:
+    failed += 1
+    print("FAIL request after refresh: %s - %s" % (i3["errcode"], i3["message"]))
+
+print("\n=== cleanup: kill_token ===")
+if keep:
+    print("SKIP --keep given - the token stays on the Miniserver")
+else:
+    step("kill_token", auth.kill_token(ms))
+    after = auth.token_info(ms)
+    if not after.get("ok") and after.get("error") == "notoken":
+        print("OK   store entry removed")
+    else:
+        failed += 1
+        print("FAIL store entry still present")
+    # a request re-fetches a token automatically - that one has to go as well
+    auth.request(ms, "/jdev/cfg/version")
+    auth.kill_token(ms)
+
+print("\n%s" % ("%d STEP(S) FAILED" % failed if failed else "ALL STEPS OK"))
+sys.exit(1 if failed else 0)


### PR DESCRIPTION
Adds a new core lib **LoxBerry::Auth** in all three supported languages. It wraps the Loxone token API so plugins no longer have to send the plaintext password on every request, and it can authenticate as **any** Miniserver user, not just the one configured in `miniserver.cgi`.

| | File |
|---|---|
| Perl | `libs/perllib/LoxBerry/Auth.pm` |
| PHP | `libs/phplib/loxberry_auth.php` (class `LBAuth`, PHP 7.4 compatible) |
| Python | `libs/pythonlib/loxberry/auth.py` (standard library only) |

Same public interface everywhere: `auth_method`, `get_token`, `refresh_token`, `kill_token`, `token_info`, `request`. `request()` returns `($content, $info)` with the same keys as `mshttp_call2`.

### Deliberately out of scope

No change to `mshttp_call2`, `miniserver.cgi` or the existing behaviour of `general.json`. The new `Authmethod` key is only *read*; when it is missing, `basicauth` applies, so nothing changes for existing installations.

### Design notes

- **No crypto stack needed.** Firmware 11.2.10.22 and up accept the token endpoints without application layer encryption, so SHA/HMAC from the standard library is enough. Older firmware gets a clear `fwtooold` error instead of a failed attempt.
- **Store**: `data/system/tokens.json`, mode 0600, keyed by **serial number** (the Miniserver number can move in `general.json`, the serial cannot). Read-modify-write happens under one exclusive `flock`, and the file is only written when the content really changed - it sits on the SD card. Password and one-time key are never persisted.
- **Default permission `0x104`** (App + Sys-WS): measured ~3 months lifetime including the right to reboot. Renewal starts at 7 days remaining and works **without the password** via `refreshjwt`.

### Three Miniserver behaviours that are easy to get wrong

Measured on firmware 17.1.7.3 while building this; all three are handled and covered by tests:

1. **`getkey2` answers 200 even for a user that does not exist** (anti-enumeration). Wrong credentials only surface at `gettoken` - and there the body is HTML, not the usual `LL` envelope.
2. **`refreshjwt` wants the plain token in `autht`**, the hash goes in the path. Hashing both consumes the one-time key twice and the request is rejected.
3. **The `LL` envelope carries its own status code, which is not always mirrored into the HTTP status** - `refreshjwt` answers HTTP 200 with `LL.code` 401. Every status check therefore goes through `_effective_code()`. The field is spelled `Code` by some endpoints and `code` by others.

### Tests

- Unit tests with an injectable transport hook, so the full flows are deterministic without a Miniserver: Perl `libs/perllib/t/auth_*.t` (176 assertions), PHP `testing/test_auth_unit.php` (152), Python `testing/test_auth_unit.py` (41).
- `libcompare` gained nine `auth_*` cases so the three implementations are checked **against each other** - a difference in the hash chain would mean the token never works in one language.
- Live scripts `testing/testauth.*` run the whole cycle against real hardware and revoke their token afterwards, so no orphans accumulate in the Miniserver's token list.

All test data is fictitious: documentation IP range (RFC 5737), placeholder password and serial. Real values come from `general.json` at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TT9mzw3YrPcupXquAS5oxt
