### PR TITLE
LoxBerry::Auth: allow POST requests with a body (Perl, PHP, Python)

### DIFF
--- a/libs/perllib/LoxBerry/Auth.pm
+++ b/libs/perllib/LoxBerry/Auth.pm
@@ -416,13 +416,34 @@ sub _http_get
 		push @headers, 'Authorization' => 'Basic '
 			. MIME::Base64::encode_base64( $opts{basicauth_user} . ':' . $pw, '' );
 	}
-	my $resp = $ua->get($url, @headers);
+	my $resp;
+	my $method = defined $opts{method} ? uc($opts{method}) : 'GET';
+	if ( $method eq 'POST' ) {
+		my $ctype = defined $opts{content_type} ? $opts{content_type}
+		                                        : 'text/plain; charset=utf-8';
+		$resp = $ua->post( $url, @headers,
+			'Content-Type' => $ctype,
+			Content        => ( defined $opts{content} ? $opts{content} : '' ) );
+	} else {
+		$resp = $ua->get($url, @headers);
+	}
+
 	# LWP fakes a 500 when the connection never happened - tell that apart
 	my $cw = $resp->header('Client-Warning');
 	if ( defined $cw and $cw eq 'Internal response' ) {
 		return (undef, undef, $resp->status_line);
 	}
 	return ($resp->code, $resp->decoded_content, $resp->status_line);
+}
+
+# request() passes its options on to get_token, cfg/api and getkey2 as well.
+# Without this filter a POST command would turn the key request into a POST too -
+# and the Miniserver does not answer that with the one-time key.
+sub _helper_opts
+{
+	my (%opts) = @_;
+	delete @opts{ qw( method content content_type ) };
+	return %opts;
 }
 
 sub _call
@@ -815,7 +836,10 @@ sub request
 	my ($ms, $command, %opts) = @_;
 	my %info = ( code => undef, status => undef, error => 1, message => '', errcode => undef );
 
-	my $tok = get_token($ms, %opts);
+	# method/content gehoeren nur an das Kommando, nicht an getkey2 & Co.
+	my %helper = _helper_opts(%opts);
+
+	my $tok = get_token($ms, %helper);
 	if (! $tok->{ok}) {
 		$info{errcode} = $tok->{error};
 		$info{message} = $tok->{message};
@@ -825,9 +849,9 @@ sub request
 	# expired -> new token; below the threshold -> renew without a password
 	my $left = int($tok->{validUntil}) - LoxBerry::System::epoch2lox();
 	if ($left <= 0) {
-		$tok = get_token($ms, %opts, force => 1);
+		$tok = get_token($ms, %helper, force => 1);
 	} elsif ($left < $REFRESH_THRESHOLD) {
-		my $r = refresh_token($ms, %opts);
+		my $r = refresh_token($ms, %helper);
 		$tok = $r if ( $r->{ok} );
 	}
 	if (! $tok->{ok}) {
@@ -836,7 +860,7 @@ sub request
 		return (undef, \%info);
 	}
 
-	my $res = _resolve_ms_probing($ms, %opts);
+	my $res = _resolve_ms_probing($ms, %helper);
 	if (! $res->{ok}) {
 		$info{errcode} = $res->{error};
 		$info{message} = $res->{message};
@@ -845,14 +869,21 @@ sub request
 
 	foreach my $attempt (1, 2) {
 		my ($url, $urlerr) = _sign_url($res->{baseurl}, $command, $tok->{token},
-		                               $tok->{user}, $res, %opts);
+		                               $tok->{user}, $res, %helper);
 		if (!$url) {
 			$info{errcode} = $urlerr->{error};
 			$info{message} = $urlerr->{message};
 			return (undef, \%info);
 		}
 
-		my ($code, $body, $status) = _call($url, %opts);
+		# Nur hier duerfen Methode und Rumpf mit - plus der Standard-Inhaltstyp
+		my %cmdopts = %opts;
+		if ( defined $cmdopts{method} and uc($cmdopts{method}) eq 'POST'
+		     and !defined $cmdopts{content_type} ) {
+			$cmdopts{content_type} = 'text/plain; charset=utf-8';
+		}
+
+		my ($code, $body, $status) = _call($url, %cmdopts);
 		if (!defined $code) {
 			$info{errcode} = 'unreachable';
 			$info{message} = "$res->{baseurl} did not answer";
@@ -867,7 +898,7 @@ sub request
 			# The token may have been deleted on the Miniserver although
 			# validUntil still looks fine. Fetch a new one and retry ONCE.
 			if ($attempt == 1) {
-				my $fresh = get_token($ms, %opts, force => 1);
+				my $fresh = get_token($ms, %helper, force => 1);
 				if ($fresh->{ok}) {
 					$tok = $fresh;
 					next;

--- a/libs/perllib/LoxBerry/testing/testauth.pl
+++ b/libs/perllib/LoxBerry/testing/testauth.pl
@@ -98,6 +98,34 @@ if ( $info3->{error} == 0 ) {
 	print "FAIL request after refresh: " . ($info3->{errcode} // '?') . " - $info3->{message}\n";
 }
 
+print "\n=== POST: setusersettings (nur wenn der Benutzer keine Sortierung hat) ===\n";
+{
+	my ($cur) = LoxBerry::Auth::request($ms, '/jdev/sps/getusersettings');
+	my $curlen = defined $cur ? length($cur) : 0;
+	if ( $curlen > 50 ) {
+		print "SKIP Benutzer hat bereits eine Sortierung ($curlen Bytes) - wird nicht ueberschrieben\n";
+	}
+	else {
+		my $ts   = LoxBerry::System::epoch2lox();
+		my $body = $ts . '/{"userDefaultStructure":{},"ts":' . $ts . ',"audioZoneCustomization":{}}';
+		my ($resp, $pinfo) = LoxBerry::Auth::request($ms, '/jdev/sps/setusersettings',
+			method  => 'POST',
+			content => $body );
+		if ( $pinfo->{error} == 0 ) {
+			print "OK   POST setusersettings (code $pinfo->{code})\n";
+			my ($back) = LoxBerry::Auth::request($ms, '/jdev/sps/getusersettings');
+			my $ok = ( defined $back and index($back, $ts) >= 0 );
+			print $ok ? "OK   Gegenprobe: der geschriebene Zeitstempel kommt zurueck\n"
+			          : "FAIL Gegenprobe: Zeitstempel nicht gefunden\n";
+			$failed++ if (!$ok);
+		}
+		else {
+			$failed++;
+			print "FAIL POST: " . ($pinfo->{errcode} // '?') . " - $pinfo->{message}\n";
+		}
+	}
+}
+
 print "\n=== cleanup: kill_token ===\n";
 if ($keep) {
 	print "SKIP --keep given - the token stays on the Miniserver\n";

--- a/libs/perllib/t/auth_flows.t
+++ b/libs/perllib/t/auth_flows.t
@@ -363,4 +363,63 @@ is( $killcall->{opts}{basicauth_password}, 'TestPass!23', 'Basic-Auth mit dem Kl
 is( LoxBerry::Auth::_store_get_token('AB:CD:EF:01:02:03', 'loxberry'), undef,
     'nach kill_token ist der Eintrag aus dem Bestand entfernt' );
 
+
+# ==========================================================================
+# POST-Unterstuetzung
+# ==========================================================================
+
+LoxBerry::Auth::_store_put_token('AB:CD:EF:01:02:03', 'loxberry',
+	{ msnr => 1, name => 'Miniserver', firmware => '17.1.7.3' },
+	{ token => 'tokTESTVALUE123', validUntil => LoxBerry::System::epoch2lox() + 60*86400,
+	  rights => 1924, perm => 260, acquired => 1, info => 'x' } );
+
+# --- GET bleibt die Vorgabe ------------------------------------------------
+@optlog = ();
+LoxBerry::Auth::request(1, '/jdev/sps/io/Test');
+my ($getcall) = grep { $_->{url} =~ m{autht=} } @optlog;
+is( $getcall->{opts}{method},  undef, 'ohne Option bleibt es ein GET' );
+is( $getcall->{opts}{content}, undef, 'ohne Option kein Rumpf' );
+
+# --- POST mit Rumpf --------------------------------------------------------
+@optlog = ();
+my $postbody = '556740899/{"userDefaultStructure":{},"ts":556740899}';
+my ($pc, $pi) = LoxBerry::Auth::request(1, '/jdev/sps/setusersettings',
+	method  => 'POST',
+	content => $postbody );
+is( $pi->{error}, 0, 'POST wird ausgefuehrt' );
+
+my ($postcall) = grep { $_->{url} =~ m{setusersettings} } @optlog;
+is( $postcall->{opts}{method},  'POST',     'Methode kommt am Transport an' );
+is( $postcall->{opts}{content}, $postbody,  'Rumpf kommt unveraendert am Transport an' );
+like( $postcall->{opts}{content_type}, qr{^text/plain}, 'Standard-Inhaltstyp ist text/plain' );
+like( $postcall->{url}, qr{\?autht=[0-9a-f]{64}&user=loxberry$},
+      'auch ein POST wird mit autht signiert' );
+
+# --- DER KERN: getkey2 darf dabei NICHT zum POST werden --------------------
+my ($keycall) = grep { $_->{url} =~ m{/jdev/sys/getkey2/} } @optlog;
+is( $keycall->{opts}{method},  undef, 'getkey2 bleibt ein GET, auch wenn das Kommando ein POST ist' );
+is( $keycall->{opts}{content}, undef, 'getkey2 bekommt keinen Rumpf' );
+
+# --- eigener Inhaltstyp ----------------------------------------------------
+@optlog = ();
+LoxBerry::Auth::request(1, '/jdev/sps/setusersettings',
+	method       => 'POST',
+	content      => '{}',
+	content_type => 'application/json' );
+my ($jsoncall) = grep { $_->{url} =~ m{setusersettings} } @optlog;
+is( $jsoncall->{opts}{content_type}, 'application/json', 'eigener Inhaltstyp wird durchgereicht' );
+
+# --- der 401-Wiederholversuch gilt auch fuer POST --------------------------
+@calls  = ();
+@optlog = ();
+$behaviour{cmd_401_once} = 1;
+my ($rc, $ri) = LoxBerry::Auth::request(1, '/jdev/sps/setusersettings',
+	method => 'POST', content => '{}' );
+is( $ri->{error}, 0, 'POST wird nach einem 401 wiederholt' );
+is( scalar( grep { m{/jdev/sys/gettoken/} } @calls ), 1,
+    'dabei wird genau ein neuer Token beschafft' );
+my ($tokcall) = grep { $_->{url} =~ m{/jdev/sys/gettoken/} } @optlog;
+is( $tokcall->{opts}{method}, undef, 'auch gettoken bleibt ein GET' );
+$behaviour{cmd_401_once} = 0;
+
 done_testing();

--- a/libs/phplib/loxberry_auth.php
+++ b/libs/phplib/loxberry_auth.php
@@ -366,6 +366,15 @@ class LBAuth
 			curl_setopt($ch, CURLOPT_USERPWD, $opts['basicauth_user'] . ':'
 			            . (isset($opts['basicauth_password']) ? $opts['basicauth_password'] : ''));
 		}
+		$method = isset($opts['method']) ? strtoupper($opts['method']) : 'GET';
+		if ($method === 'POST') {
+			$ctype   = isset($opts['content_type']) ? $opts['content_type'] : 'text/plain; charset=utf-8';
+			$payload = isset($opts['content']) ? $opts['content'] : '';
+			curl_setopt($ch, CURLOPT_POST, true);
+			curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+			curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: ' . $ctype));
+		}
+
 		$body = curl_exec($ch);
 		$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 		$err  = curl_error($ch);
@@ -373,6 +382,15 @@ class LBAuth
 		// no connection at all -> code 0
 		if ($body === false || !$code) { return array(null, null, $err ? $err : 'no connection'); }
 		return array(intval($code), $body, strval($code));
+	}
+
+	// request() passes its options on to get_token, cfg/api and getkey2 as
+	// well. Without this filter a POST command would turn the key request into
+	// a POST too - and the Miniserver does not answer that with the key.
+	public static function _helper_opts($opts)
+	{
+		unset($opts['method'], $opts['content'], $opts['content_type']);
+		return $opts;
 	}
 
 	public static function _call($url, $opts = array())
@@ -709,7 +727,10 @@ class LBAuth
 	{
 		$info = array('code' => null, 'status' => null, 'error' => 1, 'message' => '', 'errcode' => null);
 
-		$tok = self::get_token($ms, $opts);
+		// method/content gehoeren nur an das Kommando, nicht an getkey2 & Co.
+		$helper = self::_helper_opts($opts);
+
+		$tok = self::get_token($ms, $helper);
 		if (!$tok['ok']) {
 			$info['errcode'] = $tok['error']; $info['message'] = $tok['message'];
 			return array(null, $info);
@@ -717,9 +738,9 @@ class LBAuth
 
 		$left = intval($tok['validUntil']) - epoch2lox();
 		if ($left <= 0) {
-			$tok = self::get_token($ms, array_merge($opts, array('force' => 1)));
+			$tok = self::get_token($ms, array_merge($helper, array('force' => 1)));
 		} elseif ($left < self::$REFRESH_THRESHOLD) {
-			$r = self::refresh_token($ms, $opts);
+			$r = self::refresh_token($ms, $helper);
 			if ($r['ok']) { $tok = $r; }
 		}
 		if (!$tok['ok']) {
@@ -727,20 +748,27 @@ class LBAuth
 			return array(null, $info);
 		}
 
-		$res = self::_resolve_ms_probing($ms, $opts);
+		$res = self::_resolve_ms_probing($ms, $helper);
 		if (!$res['ok']) {
 			$info['errcode'] = $res['error']; $info['message'] = $res['message'];
 			return array(null, $info);
 		}
 
 		for ($attempt = 1; $attempt <= 2; $attempt++) {
-			list($url, $urlerr) = self::_sign_url($res['baseurl'], $command, $tok['token'], $tok['user'], $res, $opts);
+			list($url, $urlerr) = self::_sign_url($res['baseurl'], $command, $tok['token'], $tok['user'], $res, $helper);
 			if (!$url) {
 				$info['errcode'] = $urlerr['error']; $info['message'] = $urlerr['message'];
 				return array(null, $info);
 			}
 
-			list($code, $body, $status) = self::_call($url, $opts);
+			// Nur hier duerfen Methode und Rumpf mit - plus Standard-Inhaltstyp
+			$cmdopts = $opts;
+			if (isset($cmdopts['method']) && strtoupper($cmdopts['method']) === 'POST'
+			    && !isset($cmdopts['content_type'])) {
+				$cmdopts['content_type'] = 'text/plain; charset=utf-8';
+			}
+
+			list($code, $body, $status) = self::_call($url, $cmdopts);
 			if ($code === null) {
 				$info['errcode'] = 'unreachable';
 				$info['message'] = $res['baseurl'] . ' did not answer';
@@ -753,7 +781,7 @@ class LBAuth
 				// The token may be gone on the Miniserver although validUntil
 				// still looks fine. Fetch a new one and retry ONCE.
 				if ($attempt == 1) {
-					$fresh = self::get_token($ms, array_merge($opts, array('force' => 1)));
+					$fresh = self::get_token($ms, array_merge($helper, array('force' => 1)));
 					if ($fresh['ok']) { $tok = $fresh; continue; }
 					$info['errcode'] = $fresh['error']; $info['message'] = $fresh['message'];
 					return array(null, $info);

--- a/libs/phplib/testing/test_auth_unit.php
+++ b/libs/phplib/testing/test_auth_unit.php
@@ -470,6 +470,53 @@ t_is( $cc2['token'], 'cached2', 'put aktualisiert den Cache' );
 LBAuth::_store_del_token('AA:BB:CC:DD:EE:FF', 'cacheuser');
 t_is( LBAuth::_store_get_token('AA:BB:CC:DD:EE:FF', 'cacheuser'), null, 'del raeumt den Cache mit' );
 
+// --- POST-Unterstuetzung ---------------------------------------------------
+LBAuth::_cache_clear();
+LBAuth::_store_put_token('AB:CD:EF:01:02:03', 'loxberry',
+	array('msnr' => 1, 'name' => 'Miniserver', 'firmware' => '17.1.7.3'),
+	array('token' => 'tokTESTVALUE123', 'validUntil' => epoch2lox() + 60*86400,
+	      'rights' => 1924, 'perm' => 260, 'acquired' => 1, 'info' => 'x'));
+
+$optlog = array();
+LBAuth::request(1, '/jdev/sps/io/Test');
+$getopts = null;
+foreach ($optlog as $o) { if (strpos($o['url'], 'autht=') !== false) { $getopts = $o['opts']; } }
+t_ok( !isset($getopts['method']),  'ohne Option bleibt es ein GET' );
+t_ok( !isset($getopts['content']), 'ohne Option kein Rumpf' );
+
+$optlog = array();
+$postbody = '556740899/{"userDefaultStructure":{},"ts":556740899}';
+list($pc, $pi) = LBAuth::request(1, '/jdev/sps/setusersettings',
+	array('method' => 'POST', 'content' => $postbody));
+t_is( $pi['error'], 0, 'POST wird ausgefuehrt' );
+
+$postopts = null; $posturl = ''; $keyopts = null;
+foreach ($optlog as $o) {
+	if (strpos($o['url'], 'setusersettings') !== false)    { $postopts = $o['opts']; $posturl = $o['url']; }
+	if (strpos($o['url'], '/jdev/sys/getkey2/') !== false) { $keyopts  = $o['opts']; }
+}
+t_is( $postopts['method'],  'POST',    'Methode kommt am Transport an' );
+t_is( $postopts['content'], $postbody, 'Rumpf kommt unveraendert am Transport an' );
+t_ok( strpos($postopts['content_type'], 'text/plain') === 0, 'Standard-Inhaltstyp ist text/plain' );
+t_ok( preg_match('/\?autht=[0-9a-f]{64}&user=loxberry$/', $posturl), 'auch ein POST wird signiert' );
+
+// DER KERN: getkey2 darf dabei nicht zum POST werden
+t_ok( !isset($keyopts['method']),  'getkey2 bleibt ein GET, auch wenn das Kommando ein POST ist' );
+t_ok( !isset($keyopts['content']), 'getkey2 bekommt keinen Rumpf' );
+
+$optlog = array();
+LBAuth::request(1, '/jdev/sps/setusersettings',
+	array('method' => 'POST', 'content' => '{}', 'content_type' => 'application/json'));
+$jsonopts = null;
+foreach ($optlog as $o) { if (strpos($o['url'], 'setusersettings') !== false) { $jsonopts = $o['opts']; } }
+t_is( $jsonopts['content_type'], 'application/json', 'eigener Inhaltstyp wird durchgereicht' );
+
+$behaviour['cmd_401_once'] = 1;
+list($rc, $ri) = LBAuth::request(1, '/jdev/sps/setusersettings',
+	array('method' => 'POST', 'content' => '{}'));
+t_is( $ri['error'], 0, 'POST wird nach einem 401 wiederholt' );
+$behaviour['cmd_401_once'] = 0;
+
 echo "
 1..$count
 ";

--- a/libs/pythonlib/loxberry/auth.py
+++ b/libs/pythonlib/loxberry/auth.py
@@ -378,7 +378,16 @@ def auth_method(ms) -> str:
 # ---------------------------------------------------------------------------
 def _http_get(url, **opts):
     """Returns (code, body, status). code is None when no connection happened."""
-    req = urllib.request.Request(url)
+    method = str(opts.get("method") or "GET").upper()
+    data = None
+    if method == "POST":
+        body = opts.get("content")
+        data = (body if body is not None else "").encode("utf-8")
+
+    req = urllib.request.Request(url, data=data, method=method)
+    if method == "POST":
+        req.add_header("Content-Type",
+                       opts.get("content_type") or "text/plain; charset=utf-8")
     if opts.get("basicauth_user") is not None:
         import base64
 
@@ -417,10 +426,20 @@ def _call_opts(opts):
     return dict((k, v) for k, v in opts.items() if k in _CALL_KEYS)
 
 
+# The command in request() may carry a method and a body; the helper calls
+# (cfg/api, getkey2, gettoken, ...) must not - a POSTed getkey2 does not return
+# the one-time key. They pass **_call_opts(opts) and therefore never carry one.
+_CMD_KEYS = _CALL_KEYS + ("method", "content", "content_type")
+
+
+def _cmd_opts(opts):
+    return dict((k, v) for k, v in opts.items() if k in _CMD_KEYS)
+
+
 def _call(url, **opts):
-    _dbg("GET %s" % url)
+    _dbg("%s %s" % (str(opts.get("method") or "GET").upper(), url))
     t = transport if transport else _http_get
-    return t(url, **_call_opts(opts))
+    return t(url, **_cmd_opts(opts))
 
 
 def _ll_value(body):
@@ -807,7 +826,12 @@ def request(ms, command, **opts):
             info["message"] = urlerr["message"]
             return (None, info)
 
-        code, body, status = _call(url, **opts)
+        # Nur hier duerfen Methode und Rumpf mit - plus Standard-Inhaltstyp
+        cmdopts = dict(opts)
+        if str(cmdopts.get("method") or "").upper() == "POST"                 and not cmdopts.get("content_type"):
+            cmdopts["content_type"] = "text/plain; charset=utf-8"
+
+        code, body, status = _call(url, **cmdopts)
         if code is None:
             info["errcode"] = "unreachable"
             info["message"] = "%s did not answer" % res["baseurl"]

--- a/libs/pythonlib/testing/test_auth_unit.py
+++ b/libs/pythonlib/testing/test_auth_unit.py
@@ -519,6 +519,48 @@ class TestFlows(unittest.TestCase):
         self.assertEqual(killopts["basicauth_password"], "TestPass!23")
         self.assertIsNone(auth._store_get_token("AB:CD:EF:01:02:03", "loxberry"))
 
+    def test_get_stays_default(self):
+        self._seed()
+        auth.request(1, "/jdev/sps/io/Test")
+        opts = [o for u, o in self.ms.optlog if "autht=" in u][0]
+        self.assertNotIn("method", opts)
+        self.assertNotIn("content", opts)
+
+    def test_post_with_body(self):
+        self._seed()
+        body = '556740899/{"userDefaultStructure":{},"ts":556740899}'
+        content, info = auth.request(1, "/jdev/sps/setusersettings",
+                                     method="POST", content=body)
+        self.assertEqual(info["error"], 0)
+        url, opts = [(u, o) for u, o in self.ms.optlog if "setusersettings" in u][0]
+        self.assertEqual(opts["method"], "POST")
+        self.assertEqual(opts["content"], body)
+        self.assertTrue(opts["content_type"].startswith("text/plain"))
+        self.assertRegex(url, r"\?autht=[0-9a-f]{64}&user=loxberry$")
+
+    def test_getkey2_stays_get_during_post(self):
+        # Der Kern: der Schluesselabruf darf nicht zum POST werden
+        self._seed()
+        auth.request(1, "/jdev/sps/setusersettings", method="POST", content="{}")
+        keyopts = [o for u, o in self.ms.optlog if "/jdev/sys/getkey2/" in u][0]
+        self.assertNotIn("method", keyopts)
+        self.assertNotIn("content", keyopts)
+
+    def test_post_custom_content_type(self):
+        self._seed()
+        auth.request(1, "/jdev/sps/setusersettings",
+                     method="POST", content="{}", content_type="application/json")
+        opts = [o for u, o in self.ms.optlog if "setusersettings" in u][0]
+        self.assertEqual(opts["content_type"], "application/json")
+
+    def test_post_retries_once_on_401(self):
+        self._seed()
+        self.ms.cmd_401_once = 1
+        content, info = auth.request(1, "/jdev/sps/setusersettings",
+                                     method="POST", content="{}")
+        self.assertEqual(info["error"], 0)
+        self.assertEqual(len(self._urls("/jdev/sys/gettoken/")), 1)
+
 
 class TestProcessCache(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Follow-up to #1551. `LoxBerry::Auth::request()` could only send GET, which is enough to read from the Miniserver but not to write to it.

`jdev/sps/setusersettings` — the endpoint that stores a user's app sorting — takes the sorting as a body of roughly 55 KB and answers a GET with **501**. Without POST, a plugin that wants to write has to rebuild the signed request by hand, and every plugin would do it slightly differently.

### The interface

Three new options on `request()`, identical in all three languages:

| Option | Default | Meaning |
|---|---|---|
| `method` | `GET` | `GET` or `POST` |
| `content` | – | Body, only evaluated with `POST` |
| `content_type` | `text/plain` | Content type of the body |

Without them `request()` behaves exactly as before — existing callers are unaffected, and all previous tests stay green unchanged.

### The part that is easy to get wrong

`request()` does not only send the command. On the way it also talks to `jdev/cfg/api`, `getkey2` and possibly `gettoken`. If the method travels in the same option bundle, **`getkey2` is sent as a POST too** — and it then does not return the one-time key. The whole request fails at a place that has nothing to do with writing.

Each language therefore separates two bundles, and each has a test that pins it down:

- Perl / PHP: `_helper_opts()` strips `method`, `content` and `content_type` for the helper calls
- Python: `_call_opts()` already narrowed the options to `timeout` and `basicauth_*`; a second filter `_cmd_opts()` widens the set **for the command only**

The test is called *"getkey2 bleibt ein GET, auch wenn das Kommando ein POST ist"* and it failed before the fix — the fake transport happily accepted the POSTed `getkey2`, so only that assertion catches it.

### Verification

- Unit tests with the injectable transport: Perl 4 files (96 assertions in `auth_flows.t`), PHP 163 assertions, Python 46 tests — all green, including the pre-existing ones.
- Against a Miniserver running 17.1.7.3: `POST jdev/sps/setusersettings` answers **200**, and reading the sorting back returns the written timestamp with the content unchanged.
- The live script `testing/testauth.pl` gained a POST step that writes **only** when the user has no sorting of its own, so it cannot destroy an existing one; otherwise it reports SKIP.

All test data stays fictitious: documentation IP range, placeholder password, invented serial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TT9mzw3YrPcupXquAS5oxt
