### PR TITLE
fix(appstore): Doppelkodierung von Umlauten im Plugin-Katalog

### DIFF
--- a/libs/perllib/LoxBerry/AppStore.pm
+++ b/libs/perllib/LoxBerry/AppStore.pm
@@ -101,6 +101,24 @@ sub _cache_age_minutes {
     return (time() - $mtime) / 60;
 }
 
+# Wandelt alle dekodierten Zeichenketten einer Struktur zurueck in UTF-8-Bytes
+# (in-place, rekursiv ueber Hashes/Arrays). Siehe _read_json fuer das Warum.
+sub _encode_utf8_deep {
+    my ($node) = @_;
+    if (ref $node eq 'HASH') {
+        _encode_utf8_deep($node->{$_}) for keys %$node;
+        utf8::encode($node->{$_}) for grep { defined $node->{$_} && !ref $node->{$_} && utf8::is_utf8($node->{$_}) } keys %$node;
+    }
+    elsif (ref $node eq 'ARRAY') {
+        _encode_utf8_deep($_) for @$node;
+        for my $i (0 .. $#$node) {
+            next if ref $node->[$i] || !defined $node->[$i];
+            utf8::encode($node->[$i]) if utf8::is_utf8($node->[$i]);
+        }
+    }
+    return $node;
+}
+
 sub _read_json {
     my ($path) = @_;
     return undef unless $path && -e $path;
@@ -110,6 +128,16 @@ sub _read_json {
     open(my $fh, '<:raw', $path) or return undef;
     local $/; my $c = <$fh>; close($fh);
     my $data = eval { JSON::PP::decode_json($c) };
+    # decode_json liefert dekodierte Perl-Zeichen. Der Rest von LoxBerry
+    # (readlanguage, Templates, plugindatabase) arbeitet dagegen durchgehend mit
+    # rohen UTF-8-Bytes. Mischt HTML::Template beides in EINER Ausgabe und
+    # enthaelt irgendein Katalogfeld ein Zeichen > U+00FF (z.B. "…", "–", "→"),
+    # kann Perl den Gesamtstring beim print nicht mehr auf Bytes herunterstufen
+    # und gibt dessen interne UTF-8-Darstellung aus — die Sprachstrings werden
+    # dadurch ein zweites Mal kodiert ("BenÃ¶tigt LoxBerry ab Version").
+    # Darum hier zurueck auf Bytes: der Katalog verhaelt sich damit wie jede
+    # andere Datenquelle im Core.
+    _encode_utf8_deep($data) if $data;
     return $data;
 }
 

--- a/libs/perllib/LoxBerry/testing/testappstore_utf8.pl
+++ b/libs/perllib/LoxBerry/testing/testappstore_utf8.pl
@@ -1,0 +1,73 @@
+#!/usr/bin/perl
+
+# Regressionstest: AppStore-Katalog darf KEINE dekodierten Perl-Zeichenketten
+# an das Template liefern.
+#
+# Hintergrund (Bug "BenÃ¶tigt LoxBerry ab Version"): Sprachstrings aus
+# language_<lang>.ini sind rohe UTF-8-Bytes, JSON::PP::decode_json liefert
+# dagegen dekodierte Zeichen. Mischt HTML::Template beides in EINE Ausgabe und
+# enthaelt irgendein Katalogfeld ein Zeichen > U+00FF (z.B. "…", "–", "→"),
+# kann Perl das Ergebnis beim print nicht mehr auf Bytes herunterstufen und
+# gibt die interne UTF-8-Darstellung des GESAMTEN Strings aus. Die bereits
+# UTF-8-kodierten Sprachstrings werden dadurch ein zweites Mal kodiert.
+#
+# Aufruf: perl libs/perllib/LoxBerry/testing/testappstore_utf8.pl
+
+use strict;
+use warnings;
+use File::Temp qw(tempdir);
+use FindBin;
+use lib "$FindBin::Bin/../..";
+use LoxBerry::AppStore;
+
+my $tests = 0;
+my $fails = 0;
+
+sub ok {
+	my ($cond, $name) = @_;
+	$tests++;
+	if ($cond) { print "ok $tests - $name\n"; }
+	else       { $fails++; print "not ok $tests - $name\n"; }
+}
+
+my $dir   = tempdir(CLEANUP => 1);
+my $cache = "$dir/cache.json";
+
+# Katalog mit Umlaut (2-Byte) UND einem Zeichen > U+00FF (Ellipse, 3-Byte)
+my $json = qq({"plugins":[{"title":"H\x{c3}\x{bc}hnerklappe","description":"Steuert die T\x{c3}\x{bc}r \x{e2}\x{80}\x{a6}","zip":"https://example.org/p.zip"}]});
+open(my $fh, '>:raw', $cache) or die "cache: $!";
+print $fh $json;
+close($fh);
+
+# TTL sehr hoch -> Stufe 1 (frischer Cache), kein Netzwerkzugriff
+my ($catalog, $source) = LoxBerry::AppStore::load_catalog(undef, $cache, 999_999, "4.0.0.15", undef);
+
+ok($source eq 'cache', "Katalog kommt aus dem frischen Cache (source=$source)");
+ok(ref $catalog->{plugins} eq 'ARRAY' && @{$catalog->{plugins}} == 1, "ein Plugin geladen");
+
+my $p = $catalog->{plugins}[0];
+
+ok(!utf8::is_utf8($p->{title}),       "title ist eine Byte-Zeichenkette (kein UTF8-Flag)");
+ok(!utf8::is_utf8($p->{description}), "description ist eine Byte-Zeichenkette (kein UTF8-Flag)");
+
+ok($p->{title} eq "H\x{c3}\x{bc}hnerklappe", "title enthaelt die unveraenderten UTF-8-Bytes");
+ok($p->{description} eq "Steuert die T\x{c3}\x{bc}r \x{e2}\x{80}\x{a6}", "description enthaelt die unveraenderten UTF-8-Bytes");
+
+# Kern des Bugs: Sprachstring (Bytes) + Katalogfeld in einer Ausgabe.
+# Ergebnis muss byteweise gueltiges UTF-8 sein, nicht doppelt kodiert.
+my $langstring = "Ben\x{c3}\x{b6}tigt LoxBerry ab Version";   # wie in language_de.ini
+my $rendered   = "$langstring $p->{description}";
+my $out        = "$dir/rendered.bin";
+open(my $o, '>', $out) or die "out: $!";   # KEIN :encoding-Layer, wie CGI-STDOUT
+print $o $rendered;
+close($o);
+
+open(my $i, '<:raw', $out) or die;
+local $/; my $bytes = <$i>; close($i);
+
+ok(index($bytes, "Ben\x{c3}\x{b6}tigt") >= 0, "Sprachstring bleibt einfach UTF-8-kodiert");
+ok(index($bytes, "Ben\x{c3}\x{83}\x{c2}\x{b6}tigt") < 0, "Sprachstring ist NICHT doppelt kodiert (BenAe-Mojibake)");
+ok(index($bytes, "\x{e2}\x{80}\x{a6}") >= 0, "Zeichen > U+00FF bleibt korrektes UTF-8");
+
+print "\n$tests Tests, $fails Fehler\n";
+exit($fails ? 1 : 0);


### PR DESCRIPTION
## Symptom

Im AppStore erscheint der Versionshinweis als Mojibake — **„BenÃ¶tigt LoxBerry ab Version“** —, während die Plugin-Beschreibungen aus dem Katalog (z. B. „Omlet-Hühnertüre“) auf derselben Seite korrekt dargestellt werden.

## Ursache

Auf der Seite treffen zwei unterschiedliche Zeichenketten-Arten aufeinander:

| Quelle | Art |
|---|---|
| `readlanguage()` → `language_<lang>.ini` | rohe **UTF-8-Bytes** (kein UTF8-Flag) |
| `JSON::PP::decode_json` → Plugin-Katalog | **dekodierte Perl-Zeichen** (UTF8-Flag) |

`HTML::Template` verkettet beides zu **einem** Ausgabestring. Solange alle Katalogzeichen ≤ U+00FF sind, stuft Perl den String beim `print` verlustfrei auf Bytes herunter und alles passt. Sobald aber **irgendein** Katalogfeld ein Zeichen > U+00FF enthält (`…`, `–`, `→`, typografische Anführungszeichen, Emoji), ist das nicht mehr möglich: Perl gibt die interne UTF-8-Darstellung des **gesamten** Strings aus und protokolliert `Wide character in print` im Apache-`error.log`. Die bereits UTF-8-kodierten Sprachstrings werden dadurch ein **zweites** Mal kodiert.

Nachgestellt (identisch zum Screenshot-Symptom):

```
# Katalog nur ≤ U+00FF:
42 65 6e c3 b6 ...   ->  "Benötigt | H?hner"      (Sprachstring ok)
# Katalog mit "…" (U+2026):
42 65 6e c3 83 c2 b6 ...  ->  "BenÃ¶tigt | Hühner …"   (Sprachstring doppelt kodiert)
```

Das erklärt auch, warum der Fehler nur sporadisch auftritt: er hängt allein am Inhalt des community-gepflegten Wiki-Katalogs, nicht am LoxBerry-Stand.

## Fix

`LoxBerry::AppStore::_read_json` kodiert die dekodierte Struktur rekursiv zurück nach UTF-8-Bytes. Damit verhält sich der Katalog wie jede andere Datenquelle im Core (Sprachdateien, Plugin-DB, Templates), und die Seitenausgabe bleibt durchgehend byteweise UTF-8.

Der Fix sitzt an der einen Stelle, an der die dekodierten Zeichen ins System kommen — `appstore.cgi` und die Templates bleiben unverändert.

## Test

Neuer Regressionstest nach bestehender Konvention:

```
perl libs/perllib/LoxBerry/testing/testappstore_utf8.pl
```

9 Tests. Ohne den Fix: **6 Fehler** (plus `Wide character in print`). Mit dem Fix: **0 Fehler**.

## Nicht Teil dieses PRs

`miniserver.cgi:127/142` dekodiert ebenfalls JSON (CloudDNS bzw. `LoxApp3.json` → `msInfo.location`). Das läuft über `to_json`/`JSON`-Write statt über die Template-Ausgabe, ist also ein anderer Pfad — einen Blick wert, aber hier bewusst nicht angefasst.