### PR TITLE
fix(ui): heller Trennstrich über der Tab-Bar + Tab-Bar folgt wieder dem Theme

### DIFF
--- a/templates/system/head.html
+++ b/templates/system/head.html
@@ -8,7 +8,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=0.5, maximum-scale=3, user-scalable=yes">
 
 	<!-- jQuery Mobile theme CSS — always (provides base fonts, colors, form styles) -->
-	<link rel="stylesheet" href="/system/scripts/jquery/themes/main/loxberry.css?v=24" />
+	<link rel="stylesheet" href="/system/scripts/jquery/themes/main/loxberry.css?v=25" />
 	<!-- jQuery Mobile structure + icons — only for plugins using jQuery Mobile -->
 	<TMPL_IF LOAD_JQM>
 	<link rel="stylesheet" href="/system/scripts/jquery/themes/main/jquery.mobile.icons.min.css" />
@@ -16,10 +16,10 @@
 	</TMPL_IF>
 
 	<!-- Design System CSS — always -->
-	<link rel="stylesheet" href="/system/css/design-tokens.css?v=24" />
-	<link rel="stylesheet" href="/system/css/main.css?v=24" />
-	<link rel="stylesheet" href="/system/css/components.css?v=24" />
-	<link rel="stylesheet" href="/system/css/<TMPL_VAR THEME_FILE>?v=24" />
+	<link rel="stylesheet" href="/system/css/design-tokens.css?v=25" />
+	<link rel="stylesheet" href="/system/css/main.css?v=25" />
+	<link rel="stylesheet" href="/system/css/components.css?v=25" />
+	<link rel="stylesheet" href="/system/css/<TMPL_VAR THEME_FILE>?v=25" />
 	<link rel="shortcut icon" href="/system/images/favicon.ico" />
 	<link rel="icon" type="image/png" href="/system/images/favicon-96x96.png" sizes="96x96" />
 	<link rel="icon" type="image/png" href="/system/images/favicon-32x32.png" sizes="32x32" />
@@ -146,7 +146,7 @@
 		});
 	</script>
 	<script src="/system/scripts/browser.js"></script>
-	<script src="/system/scripts/lb-table-sort.js?v=24"></script>
+	<script src="/system/scripts/lb-table-sort.js?v=25"></script>
 	<!-- HTMLHEAD sent by the plugin author: -->
 	<TMPL_VAR HTMLHEAD>
 </head>

--- a/templates/system/head.html
+++ b/templates/system/head.html
@@ -8,7 +8,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=0.5, maximum-scale=3, user-scalable=yes">
 
 	<!-- jQuery Mobile theme CSS — always (provides base fonts, colors, form styles) -->
-	<link rel="stylesheet" href="/system/scripts/jquery/themes/main/loxberry.css?v=23" />
+	<link rel="stylesheet" href="/system/scripts/jquery/themes/main/loxberry.css?v=24" />
 	<!-- jQuery Mobile structure + icons — only for plugins using jQuery Mobile -->
 	<TMPL_IF LOAD_JQM>
 	<link rel="stylesheet" href="/system/scripts/jquery/themes/main/jquery.mobile.icons.min.css" />
@@ -16,10 +16,10 @@
 	</TMPL_IF>
 
 	<!-- Design System CSS — always -->
-	<link rel="stylesheet" href="/system/css/design-tokens.css?v=23" />
-	<link rel="stylesheet" href="/system/css/main.css?v=23" />
-	<link rel="stylesheet" href="/system/css/components.css?v=23" />
-	<link rel="stylesheet" href="/system/css/<TMPL_VAR THEME_FILE>?v=23" />
+	<link rel="stylesheet" href="/system/css/design-tokens.css?v=24" />
+	<link rel="stylesheet" href="/system/css/main.css?v=24" />
+	<link rel="stylesheet" href="/system/css/components.css?v=24" />
+	<link rel="stylesheet" href="/system/css/<TMPL_VAR THEME_FILE>?v=24" />
 	<link rel="shortcut icon" href="/system/images/favicon.ico" />
 	<link rel="icon" type="image/png" href="/system/images/favicon-96x96.png" sizes="96x96" />
 	<link rel="icon" type="image/png" href="/system/images/favicon-32x32.png" sizes="32x32" />
@@ -146,7 +146,7 @@
 		});
 	</script>
 	<script src="/system/scripts/browser.js"></script>
-	<script src="/system/scripts/lb-table-sort.js?v=23"></script>
+	<script src="/system/scripts/lb-table-sort.js?v=24"></script>
 	<!-- HTMLHEAD sent by the plugin author: -->
 	<TMPL_VAR HTMLHEAD>
 </head>

--- a/webfrontend/html/system/css/components.css
+++ b/webfrontend/html/system/css/components.css
@@ -1338,7 +1338,7 @@ a.lb-sidebar-link.active:visited {
 	padding: 6px 0;
 	padding-bottom: calc(6px + env(safe-area-inset-bottom, 0px));
 	background: var(--lb-tab-bar-bg);
-	border-top: 1px solid var(--lb-border-color);
+	border-top: 1px solid var(--lb-tab-bar-border);
 	/* Hidden by default on desktop; slid in via transform when nav-mode-tabbar
 	   is set or on mobile. Keeping display:flex (vs none) is what enables the
 	   transform/opacity animation. */

--- a/webfrontend/html/system/css/design-tokens.css
+++ b/webfrontend/html/system/css/design-tokens.css
@@ -100,15 +100,24 @@ html, body {
   --lb-radius-sm: 2px;
   --lb-border: 1px solid var(--lb-border-color);
 
-  /* === Tab Bar (mobile) === */
-  --lb-tab-bar-bg: var(--lb-sidebar-bg);
-  --lb-tab-bar-text: var(--lb-sidebar-text);
-  --lb-tab-bar-active: var(--lb-sidebar-active-text);
-  --lb-tab-bar-border: var(--lb-sidebar-border);
-
   /* === Glass extras (only used by glass theme) === */
   --lb-backdrop-blur: none;
   --lb-glow-primary: none;
   --lb-glow-danger: none;
   --lb-glow-warning: none;
+}
+
+/* === Tab Bar (mobile) ===
+   Deliberately on `body`, not `:root`: these mirror the sidebar tokens, and a
+   var() reference resolves where it is DECLARED, not where it is used. Themes
+   override the sidebar tokens on `body.theme-*` — one level below `:root` — so
+   a reference declared in `:root` would only ever see the defaults below and
+   the tab bar would stay themeless (it rendered #3d3d3d even in soft-rounded,
+   which has a white sidebar). Declared on `body`, the reference picks up the
+   active theme's value. Themes need no change. */
+body {
+  --lb-tab-bar-bg: var(--lb-sidebar-bg);
+  --lb-tab-bar-text: var(--lb-sidebar-text);
+  --lb-tab-bar-active: var(--lb-sidebar-active-text);
+  --lb-tab-bar-border: var(--lb-sidebar-border);
 }

--- a/webfrontend/html/system/css/design-tokens.css
+++ b/webfrontend/html/system/css/design-tokens.css
@@ -104,6 +104,7 @@ html, body {
   --lb-tab-bar-bg: var(--lb-sidebar-bg);
   --lb-tab-bar-text: var(--lb-sidebar-text);
   --lb-tab-bar-active: var(--lb-sidebar-active-text);
+  --lb-tab-bar-border: var(--lb-sidebar-border);
 
   /* === Glass extras (only used by glass theme) === */
   --lb-backdrop-blur: none;


### PR DESCRIPTION
Zwei zusammenhängende Fixes an der Tab-Bar, getrennt committet — der zweite ist die Ursache hinter dem ersten.

## 1. Heller Trennstrich über der Tab-Bar (`b7491119`)

Die Tab-Bar zog ihren `border-top` aus `--lb-border-color`. Das ist das Token für Ränder auf **hellen** Flächen (Cards, Inputs, Tabellen), ihr Hintergrund ist aber `--lb-sidebar-bg` (`#3d3d3d`). In classic-lb ergab das `#ddd` auf `#3d3d3d` — ein hell leuchtender Strich statt eines dezenten Trenners.

Besonders auffällig bei geöffnetem Tab-Popup: dessen Backdrop (`rgba(0,0,0,.4)`, z-index 1099) dunkelt die Seite ab, die Tab-Bar liegt mit z-index 1100 darüber und bleibt unverändert hell.

Alle anderen Trennlinien auf dunklem Grund (`components.css` 955, 997, 1052, 1521) nutzen bereits `--lb-sidebar-border`. Die Tab-Bar bekommt dafür ein eigenes Token, analog zu den vorhandenen `--lb-tab-bar-*`. Der Override in `theme-glass` bleibt unberührt.

Pixelmessung an der Kante (classic-lb, Backdrop offen):

| | über der Kante | Kante | Bar |
|---|---|---|---|
| vorher | `#949494` | **`#DDDDDD`** | `#3D3D3D` |
| nachher | `#949494` | **`#4C4C4C`** | `#3D3D3D` |

Kontrastsprung an der Kante von 160 auf 15 Helligkeitsstufen — Trennwirkung bleibt, Leuchten weg.

## 2. Die Ursache dahinter: Tab-Bar ignorierte das Theme (`16768bdd`)

Beim Gegenprüfen der anderen Themes kam heraus, warum das Token überhaupt danebengreifen konnte.

Die vier `--lb-tab-bar-*`-Tokens standen in `:root` und verweisen auf die Sidebar-Tokens. Eine `var()`-Referenz wird aber dort aufgelöst, wo sie **deklariert** ist, nicht wo sie benutzt wird — und die Themes überschreiben die Sidebar-Tokens auf `body.theme-*`, eine Ebene unter `:root`. Die Referenz sah damit immer nur die Defaults aus `design-tokens.css`.

Folge: Die Tab-Bar war themenlos. In soft-rounded rendert sie `#3d3d3d`, obwohl das Theme eine weiße Sidebar hat. In classic-lb fällt das nicht auf, weil dessen Werte mit den Defaults identisch sind — deshalb sah der Border dort nach einem reinen Farbfehler aus.

Die vier Tokens wandern deshalb aus `:root` in einen `body`-Block. Kein Theme braucht eine Anpassung.

Live geprüft (Tab-Bar-Hintergrund vs. Sidebar desselben Themes):

| Theme | Sidebar | Tab-Bar vorher | Tab-Bar nachher |
|---|---|---|---|
| classic-lb | `#3d3d3d` | `#3d3d3d` | `#3d3d3d` — unverändert |
| soft-rounded | weiß | `#3d3d3d` | **weiß** |
| clean-admin | `#1a1a2e` | `#3d3d3d` | **`#1a1a2e`** |
| glass | transparent | eigener Override | unberührt |

Das ist der sichtbare Teil des PRs: In soft-rounded und clean-admin wechselt die Tab-Bar die Farbe. Falls das so nicht gewollt ist, lässt sich Commit 2 einzeln zurücknehmen — Commit 1 steht für sich.

## Getestet

Auf einem LoxBerry 4.0.0.13 (Pi 4, classic-lb) deployt und im Browser nachgemessen: Kanten-Pixel, Computed Styles je Theme, Label-Kontraste. Cache-Buster in `head.html` auf `?v=25`.

## Ein Punkt, der euch gehört, nicht mir

In soft-rounded sitzt das **aktive** Tab-Label nach Commit 2 als `#6dac20` auf weißem statt auf dunklem Grund. Kontrast fällt damit von 3,95:1 auf 2,77:1 — bei 10px-Labels grenzwertig. Die inaktiven Labels sind mit 7,53:1 einwandfrei.

Das ist keine neue Inkonsistenz: Die Sidebar desselben Themes macht seit jeher dasselbe (`--lb-sidebar-active-text: #6dac20` auf weißer Sidebar). Die Tab-Bar verhält sich jetzt lediglich konsistent dazu und erbt eine Kontrastschwäche, die im Theme schon steckte. Sauber lösen ließe sich das nur über ein dunkleres `--lb-sidebar-active-text` in soft-rounded — was dann Sidebar **und** Bar beträfe. Das ist eine Design-Entscheidung, deshalb habe ich sie nicht getroffen, sondern melde sie nur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJymVC4JPV9QoREjbG21Fa
